### PR TITLE
Create and test PolicyRepresentation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 __pycache__/
 venv/
 dist/
+.vscode/*

--- a/src/pgeon/discretizer.py
+++ b/src/pgeon/discretizer.py
@@ -1,12 +1,14 @@
 import abc
 from enum import Enum
 from typing import Sequence, Type, Iterator
+from dataclasses import dataclass
+from typing import Collection
 
 
 class Predicate:
-    def __init__(self, predicate: Type[Enum], value: Sequence[Type[Enum]]):
+    def __init__(self, predicate: Type[Enum], value: Sequence[Enum]):
         self.predicate: Type[Enum] = predicate
-        self.value: Sequence[Type[Enum]] = value
+        self.value: Sequence[Enum] = value
 
     def __eq__(self, other):
         if not isinstance(other, Predicate):
@@ -29,12 +31,37 @@ class Predicate:
             return hash(self.predicate) < hash(other.predicate)
 
 
+@dataclass(frozen=True)
 class StateRepresentation:
-    ...
+    predicates: Collection[Predicate]
+
+    def __eq__(self, other):
+        # If comparing with a tuple, convert the tuple to a list for comparison
+        if isinstance(other, tuple):
+            # Compare the predicates with the tuple items
+            if len(self.predicates) != len(other):
+                return False
+            return all(p1 == p2 for p1, p2 in zip(self.predicates, other))
+
+        # If comparing with another StateRepresentation
+        if isinstance(other, StateRepresentation):
+            # If both are StateRepresentation, compare their predicates
+            if len(self.predicates) != len(other.predicates):
+                return False
+            return all(p1 == p2 for p1, p2 in zip(self.predicates, other.predicates))
+
+        return False
+
+    def __hash__(self):
+        return hash(tuple(self.predicates))
 
 
-class PredicateBasedStateRepresentation(StateRepresentation):
-    ...
+# Action type
+Action = int
+
+
+class PredicateBasedStateRepresentation(StateRepresentation): ...
+
 
 class Discretizer(metaclass=abc.ABCMeta):
     @classmethod

--- a/src/pgeon/discretizer.py
+++ b/src/pgeon/discretizer.py
@@ -29,6 +29,13 @@ class Predicate:
             return hash(self.predicate) < hash(other.predicate)
 
 
+class StateRepresentation:
+    ...
+
+
+class PredicateBasedStateRepresentation(StateRepresentation):
+    ...
+
 class Discretizer(metaclass=abc.ABCMeta):
     @classmethod
     def __subclasshook__(cls, subclass):

--- a/src/pgeon/discretizer.py
+++ b/src/pgeon/discretizer.py
@@ -66,7 +66,7 @@ class PredicateBasedStateRepresentation(StateRepresentation):
         return hash(tuple(self.predicates))
 
 
-# Action type
+# TODO: allow for more complex representations
 Action = int
 
 class Discretizer(metaclass=abc.ABCMeta):

--- a/src/pgeon/discretizer.py
+++ b/src/pgeon/discretizer.py
@@ -1,8 +1,7 @@
 import abc
 from enum import Enum
-from typing import Sequence, Type, Iterator
+from typing import Sequence, Type, Iterator, Collection, Union
 from dataclasses import dataclass
-from typing import Collection
 
 
 class Predicate:
@@ -31,11 +30,22 @@ class Predicate:
             return hash(self.predicate) < hash(other.predicate)
 
 
-@dataclass(frozen=True)
-class StateRepresentation:
+class StateRepresentation(abc.ABC):
     predicates: Collection[Predicate]
 
-    def __eq__(self, other):
+    @abc.abstractmethod
+    def __eq__(self, other: 'StateRepresentation') -> bool: ...
+
+    @abc.abstractmethod
+    def __hash__(self) -> int: ...
+
+
+
+@dataclass(frozen=True)
+class PredicateBasedStateRepresentation(StateRepresentation):
+    predicates: Collection[Predicate]
+
+    def __eq__(self, other: Union['PredicateBasedStateRepresentation', tuple[Predicate, ...]]) -> bool:
         # If comparing with a tuple, convert the tuple to a list for comparison
         if isinstance(other, tuple):
             # Compare the predicates with the tuple items
@@ -58,10 +68,6 @@ class StateRepresentation:
 
 # Action type
 Action = int
-
-
-class PredicateBasedStateRepresentation(StateRepresentation): ...
-
 
 class Discretizer(metaclass=abc.ABCMeta):
     @classmethod

--- a/src/pgeon/policy_approximator.py
+++ b/src/pgeon/policy_approximator.py
@@ -4,7 +4,8 @@ from gymnasium import Env
 from enum import Enum
 
 from pgeon.agent import Agent
-from pgeon.discretizer import Discretizer
+from pgeon.discretizer import Discretizer, StateRepresentation
+from pgeon.policy_representation import PolicyRepresentation
 
 
 class Base:
@@ -24,19 +25,9 @@ class Base:
 # INTENTIONAL POLICY GRAPHS = BASE POLICY GRAPH + INTENTION FUNCTIONALITY
 
 
-class StateRepresentation:
-    ...
-
-
-class PredicateBasedStateRepresentation(StateRepresentation):
-    ...
 
 
 class Desire:
-    ...
-
-
-class IntentionMixin:
     ...
 
 
@@ -45,81 +36,6 @@ class ProbabilityQuery:
 
 
 class Action:
-    ...
-
-
-class PolicyRepresentation(abc.ABC):
-    def __init__(self):
-        self._discretizer: Discretizer
-
-    @staticmethod
-    @abc.abstractmethod
-    def load(path: str) -> "PolicyRepresentation":
-        ...
-
-    @abc.abstractmethod
-    def save(self, ext: str, path: str):
-        ...
-
-    @abc.abstractmethod
-    def get_possible_actions(self, state: StateRepresentation) -> Collection[Action]:
-        ...
-
-    @abc.abstractmethod
-    def get_possible_next_states(self, state: StateRepresentation, action: Optional[Action] = None) -> Collection[StateRepresentation]:
-        ...
-
-
-class GraphRepresentation(PolicyRepresentation):
-
-    # Prolly not needed as actual classes
-    # class Node:
-    #     ...
-    #
-    # class Edge:
-    #     ...
-
-    # Package-agnostic
-    class Graph(abc.ABC):
-        ...
-
-    def __init__(self, graph_backend: str = "networkx"):
-        super().__init__()
-        # p(s) and p(s',a | s)
-        self.graph: GraphRepresentation.Graph
-        match graph_backend:
-            case "networkx":
-                self.graph = ...
-            case _:
-                raise NotImplementedError
-
-    def prob(self, query: ProbabilityQuery) -> float:
-        ...
-
-    # This refers to getting all states present in graph. Some representations may not be able to iterate over
-    #   all states.
-    def get_states_in_graph(self) -> Collection[StateRepresentation]:
-        ...
-
-    def get_possible_actions(self, state: StateRepresentation) -> Collection[Action]:
-        ...
-
-    def get_possible_next_states(self, state: StateRepresentation, action: Optional[Action] = None) -> Collection[StateRepresentation]:
-        ...
-
-    # minimum P(s',a|p) forall possible probs.
-    def get_overall_minimum_state_transition_probability(self) -> float:
-        ...
-
-    @staticmethod
-    def load(path: str) -> "PolicyRepresentation":
-        pass
-
-    def save(self, ext: str, path: str):
-        pass
-
-
-class IntentionalPG(Base, GraphRepresentation, IntentionMixin):
     ...
 
 
@@ -180,13 +96,13 @@ class PolicyApproximatorFromBasicObservation(OnlinePolicyApproximator):
             while not episode_done:
                 action = self.agent.act(state)
 
-                next_state, _, episode_done, _ = self.environment.step(action)
+                # next_state, _, episode_done, _ = self.environment.step(action)
 
-                discretized_next_state = self.discretizer.discretize(next_state)
-                episode_trajectory.append((discretized_state, action, discretized_next_state))
+                # discretized_next_state = self.discretizer.discretize(next_state)
+                # episode_trajectory.append((discretized_state, action, discretized_next_state))
                 # episode_trajectory.extend([action, discretized_next_state])
 
-                discretized_state = discretized_next_state
+                # discretized_state = discretized_next_state
                 # TODO self.policy_represenation.update_representation(episode_trajectory)
             # TODO Current pgeon version stores the episode trajectory (discretized states).
             #      Consider whether we want to keep doing that.

--- a/src/pgeon/policy_graph.py
+++ b/src/pgeon/policy_graph.py
@@ -12,7 +12,8 @@ import tqdm
 
 from pgeon.agent import Agent
 from pgeon.discretizer import Discretizer
-from pgeon.policy_approximator import PolicyRepresentation, GraphRepresentation, PolicyApproximatorFromBasicObservation
+from pgeon.policy_approximator import PolicyApproximatorFromBasicObservation
+from pgeon.policy_representation import PolicyRepresentation, GraphRepresentation
 
 
 class PolicyGraph(PolicyApproximatorFromBasicObservation):
@@ -526,7 +527,7 @@ class PolicyGraph(PolicyApproximatorFromBasicObservation):
             graph_string += (
                 f'\nMATCH (s{node_info[n_from]["id"]}:State) WHERE s{node_info[n_from]["id"]}.uid = "s{node_info[n_from]["id"]}" MATCH (s{node_info[n_to]["id"]}:State) WHERE s{node_info[n_to]["id"]}.uid = "s{node_info[n_to]["id"]}" CREATE (s{node_info[n_from]["id"]})-[:a{action_info[action]["id"]} '
                 + "{"
-                + f"probability:{self[n_from][n_to][action]['probability']}, frequency:{self[n_from][n_to][action]['frequency']}"
+                + f"probability:{self.graph[n_from][n_to][action]['probability']}, frequency:{self.graph[n_from][n_to][action]['frequency']}"
                 + "}"
                 + f"]->(s{node_info[n_to]['id']});"
             )

--- a/src/pgeon/policy_representation.py
+++ b/src/pgeon/policy_representation.py
@@ -6,7 +6,6 @@ from typing import (
     Any,
     Dict,
     Iterator,
-    TypeVar,
     cast,
     List,
 )

--- a/src/pgeon/policy_representation.py
+++ b/src/pgeon/policy_representation.py
@@ -1,0 +1,89 @@
+import abc
+from typing import Collection, Optional
+
+import networkx as nx
+
+from pgeon.discretizer import Discretizer, StateRepresentation
+from pgeon.policy_approximator import Action, ProbabilityQuery
+
+class IntentionMixin:
+    ...
+
+
+class PolicyRepresentation(abc.ABC):
+    def __init__(self):
+        self._discretizer: Discretizer
+
+    @staticmethod
+    @abc.abstractmethod
+    def load(path: str) -> "PolicyRepresentation":
+        ...
+
+    @abc.abstractmethod
+    def save(self, ext: str, path: str):
+        ...
+
+    @abc.abstractmethod
+    def get_possible_actions(self, state: StateRepresentation) -> Collection[Action]:
+        ...
+
+    @abc.abstractmethod
+    def get_possible_next_states(self, state: StateRepresentation, action: Optional[Action] = None) -> Collection[StateRepresentation]:
+        ...
+
+
+class GraphRepresentation(PolicyRepresentation):
+
+    # Prolly not needed as actual classes
+    # class Node:
+    #     ...
+    #
+    # class Edge:
+    #     ...
+
+    # Package-agnostic
+    class Graph(abc.ABC):
+        ...
+
+    class NetworkXGraph(Graph):
+        def __init__(self):
+            self.graph_backend = nx.MultiDiGraph()
+
+    def __init__(self, graph_backend: str = "networkx"):
+        super().__init__()
+        # p(s) and p(s',a | s)
+        self.graph: GraphRepresentation.Graph
+        match graph_backend:
+            case "networkx":
+                self.graph = GraphRepresentation.NetworkXGraph()
+            case _:
+                raise NotImplementedError
+
+    def prob(self, query: ProbabilityQuery) -> float:
+        ...
+
+    # This refers to getting all states present in graph. Some representations may not be able to iterate over
+    #   all states.
+    def get_states_in_graph(self) -> Collection[StateRepresentation]:
+        ...
+
+    def get_possible_actions(self, state: StateRepresentation) -> Collection[Action]:
+        ...
+
+    def get_possible_next_states(self, state: StateRepresentation, action: Optional[Action] = None) -> Collection[StateRepresentation]:
+        ...
+
+    # minimum P(s',a|p) forall possible probs.
+    def get_overall_minimum_state_transition_probability(self) -> float:
+        ...
+
+    @staticmethod
+    def load(path: str) -> "PolicyRepresentation":
+        ...
+
+    def save(self, ext: str, path: str):
+        pass
+
+
+class IntentionalPolicyGraphRepresentation(GraphRepresentation, IntentionMixin):
+    ...

--- a/src/pgeon/policy_representation.py
+++ b/src/pgeon/policy_representation.py
@@ -9,11 +9,7 @@ from typing import (
     TypeVar,
     cast,
     List,
-    Mapping,
-    Set,
-    Union,
 )
-
 import networkx as nx
 
 from pgeon.discretizer import Discretizer, StateRepresentation, Action
@@ -283,13 +279,13 @@ class GraphRepresentation(PolicyRepresentation):
         ) -> bool:
             return self._nx_graph.has_edge(node_from, node_to, key)
 
-        def nodes(self, data: bool = False) -> Iterator:
+        def nodes(self, data: bool = False) -> nx.reportviews.NodeView:
             return self._nx_graph.nodes(data=data)
 
-        def edges(self, data: bool = False) -> Iterator:
+        def edges(self, data: bool = False) -> nx.reportviews.OutMultiEdgeView:
             return self._nx_graph.edges(data=data)
 
-        def out_edges(self, node: StateRepresentation, data: bool = False) -> Iterator:
+        def out_edges(self, node: StateRepresentation, data: bool = False) -> nx.reportviews.OutMultiEdgeView:
             return self._nx_graph.out_edges(node, data=data)
 
         def clear(self) -> None:

--- a/src/pgeon/policy_representation.py
+++ b/src/pgeon/policy_representation.py
@@ -1,53 +1,312 @@
 import abc
-from typing import Collection, Optional
+from typing import (
+    Collection,
+    Optional,
+    Tuple,
+    Any,
+    Dict,
+    Iterator,
+    TypeVar,
+    cast,
+    List,
+    Mapping,
+    Set,
+    Union,
+)
 
 import networkx as nx
 
-from pgeon.discretizer import Discretizer, StateRepresentation
-from pgeon.policy_approximator import Action, ProbabilityQuery
+from pgeon.discretizer import Discretizer, StateRepresentation, Action
 
-class IntentionMixin:
-    ...
+# Define generic types for better type hinting
+S = TypeVar("S", bound=StateRepresentation)
+A = TypeVar("A", bound=Action)
+
+
+class ProbabilityQuery:
+    """
+    A class representing a probability query for policy representations.
+    """
+
+    pass  # Add implementation details as needed
+
+
+class IntentionMixin: ...
 
 
 class PolicyRepresentation(abc.ABC):
+    """
+    Abstract base class for policy representations.
+    A policy representation stores states, actions, and transitions between states.
+    """
+
     def __init__(self):
         self._discretizer: Discretizer
 
     @staticmethod
     @abc.abstractmethod
     def load(path: str) -> "PolicyRepresentation":
+        """Load a policy representation from a file."""
         ...
 
     @abc.abstractmethod
     def save(self, ext: str, path: str):
+        """Save a policy representation to a file."""
         ...
 
     @abc.abstractmethod
     def get_possible_actions(self, state: StateRepresentation) -> Collection[Action]:
+        """Get all possible actions from a state."""
         ...
 
     @abc.abstractmethod
-    def get_possible_next_states(self, state: StateRepresentation, action: Optional[Action] = None) -> Collection[StateRepresentation]:
+    def get_possible_next_states(
+        self, state: StateRepresentation, action: Optional[Action] = None
+    ) -> Collection[StateRepresentation]:
+        """Get all possible next states from a state, optionally filtered by action."""
+        ...
+
+    @abc.abstractmethod
+    def has_state(self, state: StateRepresentation) -> bool:
+        """Check if a state exists in the policy representation."""
+        ...
+
+    @abc.abstractmethod
+    def add_state(self, state: StateRepresentation, **attributes) -> None:
+        """Add a state to the policy representation with optional attributes."""
+        ...
+
+    @abc.abstractmethod
+    def add_states_from(
+        self, states: Collection[StateRepresentation], **attributes
+    ) -> None:
+        """Add multiple states to the policy representation with optional attributes."""
+        ...
+
+    @abc.abstractmethod
+    def add_transition(
+        self,
+        from_state: StateRepresentation,
+        to_state: StateRepresentation,
+        action: Action,
+        **attributes,
+    ) -> None:
+        """Add a transition between states with an action and optional attributes."""
+        ...
+
+    @abc.abstractmethod
+    def add_transitions_from(
+        self,
+        transitions: Collection[
+            Tuple[StateRepresentation, StateRepresentation, Action]
+        ],
+        **attributes,
+    ) -> None:
+        """Add multiple transitions with optional attributes."""
+        ...
+
+    @abc.abstractmethod
+    def get_transition_data(
+        self,
+        from_state: StateRepresentation,
+        to_state: StateRepresentation,
+        action: Action,
+    ) -> Dict[str, Any]:
+        """Get data associated with a specific transition."""
+        ...
+
+    @abc.abstractmethod
+    def has_transition(
+        self,
+        from_state: StateRepresentation,
+        to_state: StateRepresentation,
+        action: Optional[Action] = None,
+    ) -> bool:
+        """Check if a transition exists."""
+        ...
+
+    @abc.abstractmethod
+    def get_state_attributes(
+        self, attribute_name: str
+    ) -> Dict[StateRepresentation, Any]:
+        """Get attributes for all states by name."""
+        ...
+
+    @abc.abstractmethod
+    def set_state_attributes(
+        self, attributes: Dict[StateRepresentation, Any], attribute_name: str
+    ) -> None:
+        """Set attributes for states."""
+        ...
+
+    @abc.abstractmethod
+    def get_all_states(self) -> Collection[StateRepresentation]:
+        """Get all states in the policy representation."""
+        ...
+
+    @abc.abstractmethod
+    def get_all_transitions(self, include_data: bool = False) -> Collection[
+            Tuple[StateRepresentation, StateRepresentation, Dict[str, Any]],
+    ]:
+        """Get all transitions, optionally including associated data."""
+        ...
+
+    @abc.abstractmethod
+    def get_outgoing_transitions(
+        self, state: StateRepresentation, include_data: bool = False
+    ) -> Collection[
+            Tuple[StateRepresentation, StateRepresentation, Dict[str, Any]],
+    ]:
+        """Get all transitions originating from a state."""
+        ...
+
+    @abc.abstractmethod
+    def clear(self) -> None:
+        """Clear all states and transitions."""
+        ...
+
+    @abc.abstractmethod
+    def get_transitions_from_state(
+        self, state: StateRepresentation
+    ) -> Dict[Action, Collection[StateRepresentation]]:
+        """Get a mapping of actions to possible next states from a given state."""
         ...
 
 
 class GraphRepresentation(PolicyRepresentation):
-
-    # Prolly not needed as actual classes
-    # class Node:
-    #     ...
-    #
-    # class Edge:
-    #     ...
+    """
+    A policy representation implemented using a graph structure.
+    States are represented as nodes, and transitions as edges.
+    """
 
     # Package-agnostic
     class Graph(abc.ABC):
-        ...
+        """Abstract base class for graph implementations."""
+
+        @abc.abstractmethod
+        def add_node(self, node: StateRepresentation, **kwargs) -> None: ...
+
+        @abc.abstractmethod
+        def add_nodes_from(
+            self, nodes: Collection[StateRepresentation], **kwargs
+        ) -> None: ...
+
+        @abc.abstractmethod
+        def add_edge(
+            self, node_from: StateRepresentation, node_to: StateRepresentation, **kwargs
+        ) -> None: ...
+
+        @abc.abstractmethod
+        def add_edges_from(
+            self,
+            edges: Collection[Tuple[StateRepresentation, StateRepresentation, Any]],
+            **kwargs,
+        ) -> None: ...
+
+        @abc.abstractmethod
+        def get_edge_data(
+            self, node_from: StateRepresentation, node_to: StateRepresentation, key: Any
+        ) -> Dict[str, Any]: ...
+
+        @abc.abstractmethod
+        def has_node(self, node: StateRepresentation) -> bool: ...
+
+        @abc.abstractmethod
+        def has_edge(
+            self,
+            node_from: StateRepresentation,
+            node_to: StateRepresentation,
+            key: Any = None,
+        ) -> bool: ...
+
+        @abc.abstractmethod
+        def nodes(self, data: bool = False) -> Iterator: ...
+
+        @abc.abstractmethod
+        def edges(self, data: bool = False) -> Iterator: ...
+
+        @abc.abstractmethod
+        def out_edges(
+            self, node: StateRepresentation, data: bool = False
+        ) -> Iterator: ...
+
+        @abc.abstractmethod
+        def clear(self) -> None: ...
+
+        @abc.abstractmethod
+        def __getitem__(self, node: StateRepresentation) -> Any: ...
+
+        @property
+        @abc.abstractmethod
+        def nx_graph(self) -> nx.MultiDiGraph:
+            """Return the underlying networkx graph if available"""
+            ...
 
     class NetworkXGraph(Graph):
+        """NetworkX implementation of the Graph interface."""
+
         def __init__(self):
-            self.graph_backend = nx.MultiDiGraph()
+            # Not calling super().__init__() since Graph is an ABC
+            self._nx_graph = nx.MultiDiGraph()
+
+        def __getitem__(self, node: StateRepresentation) -> Any:
+            return cast(
+                Dict[StateRepresentation, Dict[Any, Dict[str, Any]]],
+                self._nx_graph[node],
+            )
+
+        def add_node(self, node: StateRepresentation, **kwargs) -> None:
+            self._nx_graph.add_node(node, **kwargs)
+
+        def add_nodes_from(
+            self, nodes: Collection[StateRepresentation], **kwargs
+        ) -> None:
+            self._nx_graph.add_nodes_from(nodes, **kwargs)
+
+        def add_edge(
+            self, node_from: StateRepresentation, node_to: StateRepresentation, **kwargs
+        ) -> None:
+            self._nx_graph.add_edge(node_from, node_to, **kwargs)
+
+        def add_edges_from(
+            self,
+            edges: Collection[Tuple[StateRepresentation, StateRepresentation, Any]],
+            **kwargs,
+        ) -> None:
+            self._nx_graph.add_edges_from(edges, **kwargs)
+
+        def get_edge_data(
+            self, node_from: StateRepresentation, node_to: StateRepresentation, key: Any
+        ) -> Dict[str, Any]:
+            data = self._nx_graph.get_edge_data(node_from, node_to, key)
+            return cast(Dict[str, Any], data) if data else {}
+
+        def has_node(self, node: StateRepresentation) -> bool:
+            return self._nx_graph.has_node(node)
+
+        def has_edge(
+            self,
+            node_from: StateRepresentation,
+            node_to: StateRepresentation,
+            key: Any = None,
+        ) -> bool:
+            return self._nx_graph.has_edge(node_from, node_to, key)
+
+        def nodes(self, data: bool = False) -> Iterator:
+            return self._nx_graph.nodes(data=data)
+
+        def edges(self, data: bool = False) -> Iterator:
+            return self._nx_graph.edges(data=data)
+
+        def out_edges(self, node: StateRepresentation, data: bool = False) -> Iterator:
+            return self._nx_graph.out_edges(node, data=data)
+
+        def clear(self) -> None:
+            self._nx_graph.clear()
+
+        @property
+        def nx_graph(self) -> nx.MultiDiGraph:
+            return self._nx_graph
 
     def __init__(self, graph_backend: str = "networkx"):
         super().__init__()
@@ -60,30 +319,204 @@ class GraphRepresentation(PolicyRepresentation):
                 raise NotImplementedError
 
     def prob(self, query: ProbabilityQuery) -> float:
+        """Calculate probability for a given query."""
         ...
 
-    # This refers to getting all states present in graph. Some representations may not be able to iterate over
-    #   all states.
-    def get_states_in_graph(self) -> Collection[StateRepresentation]:
-        ...
-
+    # Implementation of PolicyRepresentation interface using graph terminology
     def get_possible_actions(self, state: StateRepresentation) -> Collection[Action]:
-        ...
+        """Get all possible actions from a state."""
+        if not self.has_state(state):
+            return []
+        actions = set()
+        for _, _, data in self.graph.out_edges(state, data=True):
+            if "action" in data:
+                actions.add(data["action"])
+        return list(actions)
 
-    def get_possible_next_states(self, state: StateRepresentation, action: Optional[Action] = None) -> Collection[StateRepresentation]:
-        ...
+    def get_possible_next_states(
+        self, state: StateRepresentation, action: Optional[Action] = None
+    ) -> Collection[StateRepresentation]:
+        """Get all possible next states from a state, optionally filtered by action."""
+        if not self.has_state(state):
+            return []
+        if action is None:
+            return [to_state for _, to_state in self.graph.out_edges(state)]
+        next_states = []
+        for _, to_state, data in self.graph.out_edges(state, data=True):
+            if "action" in data and data["action"] == action:
+                next_states.append(to_state)
+        return next_states
+
+    def has_state(self, state: StateRepresentation) -> bool:
+        """Check if a state exists in the policy representation."""
+        return self.graph.has_node(state)
+
+    def add_state(self, state: StateRepresentation, **attributes) -> None:
+        """Add a state to the policy representation with optional attributes."""
+        self.graph.add_node(state, **attributes)
+
+    def add_states_from(
+        self, states: Collection[StateRepresentation], **attributes
+    ) -> None:
+        """Add multiple states to the policy representation with optional attributes."""
+        self.graph.add_nodes_from(states, **attributes)
+
+    def add_transition(
+        self,
+        from_state: StateRepresentation,
+        to_state: StateRepresentation,
+        action: Action,
+        **attributes,
+    ) -> None:
+        """Add a transition between states with an action and optional attributes."""
+        all_attributes = attributes.copy()
+        all_attributes["action"] = action
+        self.graph.add_edge(from_state, to_state, key=action, **all_attributes)
+
+    def add_transitions_from(
+        self,
+        transitions: Collection[
+            Tuple[StateRepresentation, StateRepresentation, Action]
+        ],
+        **attributes,
+    ) -> None:
+        """Add multiple transitions with optional attributes."""
+        for from_state, to_state, action in transitions:
+            self.add_transition(from_state, to_state, action, **attributes)
+
+    def get_transition_data(
+        self,
+        from_state: StateRepresentation,
+        to_state: StateRepresentation,
+        action: Action,
+    ) -> Dict[str, Any]:
+        """Get data associated with a specific transition."""
+        data = self.graph.get_edge_data(from_state, to_state, action)
+        return data if data else {}
+
+    def has_transition(
+        self,
+        from_state: StateRepresentation,
+        to_state: StateRepresentation,
+        action: Optional[Action] = None,
+    ) -> bool:
+        """Check if a transition exists."""
+        return self.graph.has_edge(from_state, to_state, action)
+
+    def get_state_attributes(
+        self, attribute_name: str
+    ) -> Dict[StateRepresentation, Any]:
+        """Get attributes for all states by name."""
+        return nx.get_node_attributes(self.graph.nx_graph, attribute_name)
+
+    def set_state_attributes(
+        self, attributes: Dict[StateRepresentation, Any], attribute_name: str
+    ) -> None:
+        """Set attributes for states."""
+        nx.set_node_attributes(self.graph.nx_graph, attributes, attribute_name)
+
+    def get_all_states(self) -> Collection[StateRepresentation]:
+        """Get all states in the policy representation."""
+        return list(self.graph.nodes())
+
+    def get_all_transitions(self, include_data: bool = False) -> Collection:
+        """Get all transitions, optionally including associated data."""
+        return list(self.graph.edges(data=include_data))
+
+    def get_outgoing_transitions(
+        self, state: StateRepresentation, include_data: bool = False
+    ) -> Collection:
+        """Get all transitions originating from a state."""
+        return list(self.graph.out_edges(state, data=include_data))
+
+    def clear(self) -> None:
+        """Clear all states and transitions."""
+        self.graph.clear()
+
+    def get_transitions_from_state(
+        self, state: StateRepresentation
+    ) -> Dict[Action, List[StateRepresentation]]:
+        """Get a mapping of actions to possible next states from a given state."""
+        if not self.has_state(state):
+            return {}
+
+        result = {}
+        for _, to_state, data in self.graph.out_edges(state, data=True):
+            if "action" in data:
+                action = data["action"]
+                if action not in result:
+                    result[action] = []
+                result[action].append(to_state)
+        return result
+
+    # Legacy methods for backward compatibility
+    def has_node(self, node: StateRepresentation) -> bool:
+        return self.has_state(node)
+
+    def add_node(self, node: StateRepresentation, **kwargs) -> None:
+        self.add_state(node, **kwargs)
+
+    def add_nodes_from(self, nodes: Collection[StateRepresentation], **kwargs) -> None:
+        self.add_states_from(nodes, **kwargs)
+
+    def add_edge(
+        self, node_from: StateRepresentation, node_to: StateRepresentation, **kwargs
+    ) -> None:
+        action = kwargs.pop("action", None)
+        if action is not None:
+            self.add_transition(node_from, node_to, action, **kwargs)
+        else:
+            self.graph.add_edge(node_from, node_to, **kwargs)
+
+    def add_edges_from(
+        self,
+        edges: Collection[Tuple[StateRepresentation, StateRepresentation, Action]],
+        **kwargs,
+    ) -> None:
+        self.add_transitions_from(edges, **kwargs)
+
+    def get_edge_data(
+        self, node_from: StateRepresentation, node_to: StateRepresentation, key: Any
+    ) -> Dict:
+        return self.get_transition_data(node_from, node_to, key)
+
+    def has_edge(
+        self,
+        node_from: StateRepresentation,
+        node_to: StateRepresentation,
+        key: Any = None,
+    ) -> bool:
+        return self.has_transition(node_from, node_to, key)
+
+    def get_node_attributes(self, name: str) -> Dict[StateRepresentation, Any]:
+        return self.get_state_attributes(name)
+
+    def set_node_attributes(
+        self, attributes: Dict[StateRepresentation, Any], name: str
+    ) -> None:
+        self.set_state_attributes(attributes, name)
+
+    def nodes(self) -> Collection[StateRepresentation]:
+        return self.get_all_states()
+
+    def edges(self, data: bool = False):
+        return self.get_all_transitions(include_data=data)
+
+    def out_edges(self, node: StateRepresentation, data: bool = False):
+        return self.get_outgoing_transitions(node, include_data=data)
+
+    def __getitem__(self, state: StateRepresentation) -> Any:
+        """Get the transitions from a state, organized by destination state."""
+        return self.graph[state]
 
     # minimum P(s',a|p) forall possible probs.
-    def get_overall_minimum_state_transition_probability(self) -> float:
-        ...
+    def get_overall_minimum_state_transition_probability(self) -> float: ...
 
     @staticmethod
-    def load(path: str) -> "PolicyRepresentation":
-        ...
+    def load(path: str) -> "PolicyRepresentation": ...
 
     def save(self, ext: str, path: str):
         pass
 
 
-class IntentionalPolicyGraphRepresentation(GraphRepresentation, IntentionMixin):
-    ...
+class IntentionalPolicyGraphRepresentation(GraphRepresentation, IntentionMixin): ...

--- a/src/pgeon/policy_representation.py
+++ b/src/pgeon/policy_representation.py
@@ -18,17 +18,8 @@ import networkx as nx
 
 from pgeon.discretizer import Discretizer, StateRepresentation, Action
 
-# Define generic types for better type hinting
-S = TypeVar("S", bound=StateRepresentation)
-A = TypeVar("A", bound=Action)
 
-
-class ProbabilityQuery:
-    """
-    A class representing a probability query for policy representations.
-    """
-
-    pass  # Add implementation details as needed
+class ProbabilityQuery: ...
 
 
 class IntentionMixin: ...

--- a/src/pgeon/policy_representation.py
+++ b/src/pgeon/policy_representation.py
@@ -131,18 +131,16 @@ class PolicyRepresentation(abc.ABC):
         ...
 
     @abc.abstractmethod
-    def get_all_transitions(self, include_data: bool = False) -> Collection[
-            Tuple[StateRepresentation, StateRepresentation, Dict[str, Any]],
-    ]:
+    def get_all_transitions(
+        self, include_data: bool = False
+    ) -> Collection[Tuple[StateRepresentation, StateRepresentation, Dict[str, Any]],]:
         """Get all transitions, optionally including associated data."""
         ...
 
     @abc.abstractmethod
     def get_outgoing_transitions(
         self, state: StateRepresentation, include_data: bool = False
-    ) -> Collection[
-            Tuple[StateRepresentation, StateRepresentation, Dict[str, Any]],
-    ]:
+    ) -> Collection[Tuple[StateRepresentation, StateRepresentation, Dict[str, Any]],]:
         """Get all transitions originating from a state."""
         ...
 
@@ -284,7 +282,9 @@ class GraphRepresentation(PolicyRepresentation):
         def edges(self, data: bool = False) -> nx.reportviews.OutMultiEdgeView:
             return self._nx_graph.edges(data=data)
 
-        def out_edges(self, node: StateRepresentation, data: bool = False) -> nx.reportviews.OutMultiEdgeView:
+        def out_edges(
+            self, node: StateRepresentation, data: bool = False
+        ) -> nx.reportviews.OutMultiEdgeView:
             return self._nx_graph.out_edges(node, data=data)
 
         def clear(self) -> None:
@@ -298,11 +298,10 @@ class GraphRepresentation(PolicyRepresentation):
         super().__init__()
         # p(s) and p(s',a | s)
         self.graph: GraphRepresentation.Graph
-        match graph_backend:
-            case "networkx":
-                self.graph = GraphRepresentation.NetworkXGraph()
-            case _:
-                raise NotImplementedError
+        if graph_backend == "networkx":
+            self.graph = GraphRepresentation.NetworkXGraph()
+        else:
+            raise NotImplementedError(f"Graph backend {graph_backend} not implemented")
 
     def prob(self, query: ProbabilityQuery) -> float:
         """Calculate probability for a given query."""

--- a/test/pgeon/test_policy_representation.py
+++ b/test/pgeon/test_policy_representation.py
@@ -11,9 +11,7 @@ from pgeon.policy_representation import Action
 
 
 class TestPolicyRepresentation(unittest.TestCase):
-    """
-    Tests for the PolicyRepresentation and GraphRepresentation classes.
-    """
+    """Tests for the PolicyRepresentation and GraphRepresentation classes."""
 
     def setUp(self):
         """Set up test data before each test."""
@@ -25,10 +23,7 @@ class TestPolicyRepresentation(unittest.TestCase):
         self.state2 = StateRepresentation((Predicate(State, [State.TWO]),))
         self.state3 = StateRepresentation((Predicate(State, [State.THREE]),))
 
-        # TestingEnv only supports action 0
         self.action0: Action = 0
-
-        # Initialize a GraphRepresentation for testing
         self.representation = GraphRepresentation()
 
     def test_initialization(self):
@@ -39,14 +34,11 @@ class TestPolicyRepresentation(unittest.TestCase):
 
     def test_add_state(self):
         """Test adding states to the representation."""
-        # Add a single state
         self.representation.add_state(self.state0, frequency=1, probability=0.25)
 
-        # Verify state was added correctly
         self.assertTrue(self.representation.has_state(self.state0))
         self.assertEqual(len(self.representation.get_all_states()), 1)
 
-        # Test with attributes
         state_attrs = self.representation.get_state_attributes("frequency")
         self.assertEqual(state_attrs[self.state0], 1)
 
@@ -55,13 +47,11 @@ class TestPolicyRepresentation(unittest.TestCase):
             [self.state1, self.state2, self.state3], frequency=2, probability=0.25
         )
 
-        # Verify states were added correctly
         self.assertTrue(self.representation.has_state(self.state1))
         self.assertTrue(self.representation.has_state(self.state2))
         self.assertTrue(self.representation.has_state(self.state3))
         self.assertEqual(len(self.representation.get_all_states()), 4)
 
-        # Test with attributes
         state_attrs = self.representation.get_state_attributes("frequency")
         self.assertEqual(state_attrs[self.state1], 2)
         self.assertEqual(state_attrs[self.state2], 2)
@@ -69,24 +59,20 @@ class TestPolicyRepresentation(unittest.TestCase):
 
     def test_add_transition(self):
         """Test adding transitions to the representation."""
-        # Add states first
         self.representation.add_states_from(
             [self.state0, self.state1, self.state2, self.state3], frequency=1
         )
 
-        # Add a single transition
         self.representation.add_transition(
             self.state0, self.state1, self.action0, frequency=5, probability=1.0
         )
 
-        # Verify transition was added correctly
         self.assertTrue(self.representation.has_transition(self.state0, self.state1))
         self.assertTrue(
             self.representation.has_transition(self.state0, self.state1, self.action0)
         )
         self.assertEqual(len(self.representation.get_all_transitions()), 1)
 
-        # Test with attributes
         transition_data = self.representation.get_transition_data(
             self.state0, self.state1, self.action0
         )
@@ -104,7 +90,6 @@ class TestPolicyRepresentation(unittest.TestCase):
             transitions, frequency=3, probability=0.75
         )
 
-        # Verify transitions were added correctly
         self.assertTrue(
             self.representation.has_transition(self.state1, self.state2, self.action0)
         )
@@ -116,7 +101,6 @@ class TestPolicyRepresentation(unittest.TestCase):
         )
         self.assertEqual(len(self.representation.get_all_transitions()), 4)
 
-        # Test with attributes
         transition_data = self.representation.get_transition_data(
             self.state1, self.state2, self.action0
         )
@@ -125,80 +109,69 @@ class TestPolicyRepresentation(unittest.TestCase):
 
     def test_get_possible_actions(self):
         """Test getting possible actions from a state."""
-        # Setup states and transitions
         self.setup_test_graph()
 
-        # Test with a state that has outgoing transitions
         actions = self.representation.get_possible_actions(self.state0)
         self.assertEqual(len(actions), 1)
         self.assertIn(self.action0, actions)
 
-        # Test with a state that has no outgoing transitions - not applicable for our test env
-        # All states have outgoing transitions in our cycle
-
-        # Test with a state that doesn't exist
-        nonexistent_state = StateRepresentation((Predicate(State, [State.ZERO]), Predicate(State, [State.ONE])))
+        nonexistent_state = StateRepresentation(
+            (Predicate(State, [State.ZERO]), Predicate(State, [State.ONE]))
+        )
         actions = self.representation.get_possible_actions(nonexistent_state)
         self.assertEqual(len(actions), 0)
 
     def test_get_possible_next_states(self):
         """Test getting possible next states from a state."""
-        # Setup states and transitions
         self.setup_test_graph()
 
-        # Test with a state and specific action
         next_states = self.representation.get_possible_next_states(
             self.state0, self.action0
         )
         self.assertEqual(len(next_states), 1)
         self.assertIn(self.state1, next_states)
 
-        # Test with a state and no action specified (all actions)
         next_states = self.representation.get_possible_next_states(self.state0)
         self.assertEqual(len(next_states), 1)
         self.assertIn(self.state1, next_states)
 
-        # Test with a state that doesn't exist
-        nonexistent_state = StateRepresentation((Predicate(State, [State.ZERO]), Predicate(State, [State.ONE])))
+        nonexistent_state = StateRepresentation(
+            (Predicate(State, [State.ZERO]), Predicate(State, [State.ONE]))
+        )
         next_states = self.representation.get_possible_next_states(nonexistent_state)
         self.assertEqual(len(next_states), 0)
 
     def test_get_transitions_from_state(self):
         """Test getting transitions from a state, grouped by action."""
-        # Setup states and transitions
         self.setup_test_graph()
 
-        # Test with a state that has outgoing transitions
         transitions = self.representation.get_transitions_from_state(self.state0)
         self.assertEqual(len(transitions), 1)
         self.assertIn(self.action0, transitions)
         self.assertIn(self.state1, transitions[self.action0])
 
-        # Test with a state that doesn't exist
-        nonexistent_state = StateRepresentation((Predicate(State, [State.ZERO]), Predicate(State, [State.ONE])))
+        nonexistent_state = StateRepresentation(
+            (Predicate(State, [State.ZERO]), Predicate(State, [State.ONE]))
+        )
         transitions = self.representation.get_transitions_from_state(nonexistent_state)
         self.assertEqual(len(transitions), 0)
 
     def test_get_state_attributes(self):
         """Test getting and setting state attributes."""
-        # Setup states with attributes
         self.representation.add_states_from(
             [self.state0, self.state1, self.state2, self.state3],
             frequency=1,
             probability=0.25,
         )
 
-        # Test getting an attribute
         attrs = self.representation.get_state_attributes("frequency")
         self.assertEqual(len(attrs), 4)
         self.assertEqual(attrs[self.state0], 1)
         self.assertEqual(attrs[self.state1], 1)
 
-        # Test setting attributes
         new_attrs = {self.state0: 10, self.state1: 20}
         self.representation.set_state_attributes(new_attrs, "frequency")
 
-        # Verify attributes were updated
         attrs = self.representation.get_state_attributes("frequency")
         self.assertEqual(attrs[self.state0], 10)
         self.assertEqual(attrs[self.state1], 20)
@@ -206,16 +179,13 @@ class TestPolicyRepresentation(unittest.TestCase):
 
     def test_get_outgoing_transitions(self):
         """Test getting outgoing transitions from a state."""
-        # Setup states and transitions
         self.setup_test_graph()
 
-        # Test without data
         transitions = self.representation.get_outgoing_transitions(
             self.state0, include_data=False
         )
         self.assertEqual(len(transitions), 1)
 
-        # Test with data
         transitions = self.representation.get_outgoing_transitions(
             self.state0, include_data=True
         )
@@ -227,26 +197,20 @@ class TestPolicyRepresentation(unittest.TestCase):
 
     def test_clear(self):
         """Test clearing the representation."""
-        # Setup states and transitions
         self.setup_test_graph()
 
-        # Verify setup
         self.assertEqual(len(self.representation.get_all_states()), 4)
         self.assertEqual(len(self.representation.get_all_transitions()), 4)
 
-        # Clear the representation
         self.representation.clear()
 
-        # Verify clearing worked
         self.assertEqual(len(self.representation.get_all_states()), 0)
         self.assertEqual(len(self.representation.get_all_transitions()), 0)
 
     def test_backward_compatibility(self):
         """Test that the backward compatibility methods work correctly."""
-        # Setup states and transitions
         self.setup_test_graph()
 
-        # Test old methods against new methods
         self.assertEqual(
             len(self.representation.nodes()), len(self.representation.get_all_states())
         )
@@ -259,12 +223,10 @@ class TestPolicyRepresentation(unittest.TestCase):
             len(self.representation.get_outgoing_transitions(self.state0)),
         )
 
-        # Test node attributes
         old_attrs = self.representation.get_node_attributes("frequency")
         new_attrs = self.representation.get_state_attributes("frequency")
         self.assertEqual(old_attrs, new_attrs)
 
-        # Test edge data
         old_data = self.representation.get_edge_data(
             self.state0, self.state1, self.action0
         )
@@ -275,20 +237,15 @@ class TestPolicyRepresentation(unittest.TestCase):
 
     def test_simulation_with_environment(self):
         """Test simulating a policy with the TestingEnv environment."""
-        # Create a fresh environment
         env = TestingEnv()
-
-        # Create a representation and populate it
         self.representation.clear()
 
-        # Add states
         self.representation.add_states_from(
             [self.state0, self.state1, self.state2, self.state3],
             frequency=1,
             probability=0.25,
         )
 
-        # Add transitions that match the environment behavior
         transitions: List[Tuple[StateRepresentation, StateRepresentation, Action]] = [
             (self.state0, self.state1, self.action0),
             (self.state1, self.state2, self.action0),
@@ -299,24 +256,18 @@ class TestPolicyRepresentation(unittest.TestCase):
             transitions, frequency=1, probability=1.0
         )
 
-        # Test simulation
         obs, _ = env.reset()
-
-        # Check that the initial observation matches our discretization
         initial_state = StateRepresentation(self.discretizer.discretize(obs))
         self.assertEqual(initial_state, self.state0)
 
-        # Make one step and verify transition
         state = initial_state
         next_obs, _, _, _, _ = env.step(self.action0)
         next_state = StateRepresentation(self.discretizer.discretize(next_obs))
 
-        # Check that the state transition is as expected
         self.assertTrue(
             self.representation.has_transition(state, next_state, self.action0)
         )
 
-        # Get possible next states from representation
         possible_next_states = self.representation.get_possible_next_states(
             state, self.action0
         )
@@ -324,17 +275,14 @@ class TestPolicyRepresentation(unittest.TestCase):
 
     def setup_test_graph(self):
         """Helper method to set up a test graph for multiple tests."""
-        # Clear any existing data
         self.representation.clear()
 
-        # Add states
         self.representation.add_states_from(
             [self.state0, self.state1, self.state2, self.state3],
             frequency=1,
             probability=0.25,
         )
 
-        # Add transitions - in TestingEnv, we can only do action 0 and it cycles through states
         transitions: List[Tuple[StateRepresentation, StateRepresentation, Action]] = [
             (self.state0, self.state1, self.action0),
             (self.state1, self.state2, self.action0),

--- a/test/pgeon/test_policy_representation.py
+++ b/test/pgeon/test_policy_representation.py
@@ -1,0 +1,350 @@
+import unittest
+from typing import Dict, Any, Tuple, cast, Optional, List
+
+import networkx as nx
+import numpy as np
+
+from pgeon import GraphRepresentation, Predicate
+from test.domain.test_env import State, TestingDiscretizer, TestingEnv
+from pgeon.discretizer import StateRepresentation
+from pgeon.policy_representation import Action
+
+
+class TestPolicyRepresentation(unittest.TestCase):
+    """
+    Tests for the PolicyRepresentation and GraphRepresentation classes.
+    """
+
+    def setUp(self):
+        """Set up test data before each test."""
+        self.discretizer = TestingDiscretizer()
+
+        # Create states and actions for testing
+        self.state0 = StateRepresentation((Predicate(State, [State.ZERO]),))
+        self.state1 = StateRepresentation((Predicate(State, [State.ONE]),))
+        self.state2 = StateRepresentation((Predicate(State, [State.TWO]),))
+        self.state3 = StateRepresentation((Predicate(State, [State.THREE]),))
+
+        # TestingEnv only supports action 0
+        self.action0: Action = 0
+
+        # Initialize a GraphRepresentation for testing
+        self.representation = GraphRepresentation()
+
+    def test_initialization(self):
+        """Test initialization of policy representation."""
+        self.assertIsInstance(self.representation.graph.nx_graph, nx.MultiDiGraph)
+        self.assertEqual(len(self.representation.get_all_states()), 0)
+        self.assertEqual(len(self.representation.get_all_transitions()), 0)
+
+    def test_add_state(self):
+        """Test adding states to the representation."""
+        # Add a single state
+        self.representation.add_state(self.state0, frequency=1, probability=0.25)
+
+        # Verify state was added correctly
+        self.assertTrue(self.representation.has_state(self.state0))
+        self.assertEqual(len(self.representation.get_all_states()), 1)
+
+        # Test with attributes
+        state_attrs = self.representation.get_state_attributes("frequency")
+        self.assertEqual(state_attrs[self.state0], 1)
+
+        # Add multiple states
+        self.representation.add_states_from(
+            [self.state1, self.state2, self.state3], frequency=2, probability=0.25
+        )
+
+        # Verify states were added correctly
+        self.assertTrue(self.representation.has_state(self.state1))
+        self.assertTrue(self.representation.has_state(self.state2))
+        self.assertTrue(self.representation.has_state(self.state3))
+        self.assertEqual(len(self.representation.get_all_states()), 4)
+
+        # Test with attributes
+        state_attrs = self.representation.get_state_attributes("frequency")
+        self.assertEqual(state_attrs[self.state1], 2)
+        self.assertEqual(state_attrs[self.state2], 2)
+        self.assertEqual(state_attrs[self.state3], 2)
+
+    def test_add_transition(self):
+        """Test adding transitions to the representation."""
+        # Add states first
+        self.representation.add_states_from(
+            [self.state0, self.state1, self.state2, self.state3], frequency=1
+        )
+
+        # Add a single transition
+        self.representation.add_transition(
+            self.state0, self.state1, self.action0, frequency=5, probability=1.0
+        )
+
+        # Verify transition was added correctly
+        self.assertTrue(self.representation.has_transition(self.state0, self.state1))
+        self.assertTrue(
+            self.representation.has_transition(self.state0, self.state1, self.action0)
+        )
+        self.assertEqual(len(self.representation.get_all_transitions()), 1)
+
+        # Test with attributes
+        transition_data = self.representation.get_transition_data(
+            self.state0, self.state1, self.action0
+        )
+        self.assertEqual(transition_data["frequency"], 5)
+        self.assertEqual(transition_data["probability"], 1.0)
+        self.assertEqual(transition_data["action"], self.action0)
+
+        # Add multiple transitions
+        transitions: List[Tuple[StateRepresentation, StateRepresentation, Action]] = [
+            (self.state1, self.state2, self.action0),
+            (self.state2, self.state3, self.action0),
+            (self.state3, self.state0, self.action0),
+        ]
+        self.representation.add_transitions_from(
+            transitions, frequency=3, probability=0.75
+        )
+
+        # Verify transitions were added correctly
+        self.assertTrue(
+            self.representation.has_transition(self.state1, self.state2, self.action0)
+        )
+        self.assertTrue(
+            self.representation.has_transition(self.state2, self.state3, self.action0)
+        )
+        self.assertTrue(
+            self.representation.has_transition(self.state3, self.state0, self.action0)
+        )
+        self.assertEqual(len(self.representation.get_all_transitions()), 4)
+
+        # Test with attributes
+        transition_data = self.representation.get_transition_data(
+            self.state1, self.state2, self.action0
+        )
+        self.assertEqual(transition_data["frequency"], 3)
+        self.assertEqual(transition_data["probability"], 0.75)
+
+    def test_get_possible_actions(self):
+        """Test getting possible actions from a state."""
+        # Setup states and transitions
+        self.setup_test_graph()
+
+        # Test with a state that has outgoing transitions
+        actions = self.representation.get_possible_actions(self.state0)
+        self.assertEqual(len(actions), 1)
+        self.assertIn(self.action0, actions)
+
+        # Test with a state that has no outgoing transitions - not applicable for our test env
+        # All states have outgoing transitions in our cycle
+
+        # Test with a state that doesn't exist
+        nonexistent_state = StateRepresentation((Predicate(State, [State.ZERO]), Predicate(State, [State.ONE])))
+        actions = self.representation.get_possible_actions(nonexistent_state)
+        self.assertEqual(len(actions), 0)
+
+    def test_get_possible_next_states(self):
+        """Test getting possible next states from a state."""
+        # Setup states and transitions
+        self.setup_test_graph()
+
+        # Test with a state and specific action
+        next_states = self.representation.get_possible_next_states(
+            self.state0, self.action0
+        )
+        self.assertEqual(len(next_states), 1)
+        self.assertIn(self.state1, next_states)
+
+        # Test with a state and no action specified (all actions)
+        next_states = self.representation.get_possible_next_states(self.state0)
+        self.assertEqual(len(next_states), 1)
+        self.assertIn(self.state1, next_states)
+
+        # Test with a state that doesn't exist
+        nonexistent_state = StateRepresentation((Predicate(State, [State.ZERO]), Predicate(State, [State.ONE])))
+        next_states = self.representation.get_possible_next_states(nonexistent_state)
+        self.assertEqual(len(next_states), 0)
+
+    def test_get_transitions_from_state(self):
+        """Test getting transitions from a state, grouped by action."""
+        # Setup states and transitions
+        self.setup_test_graph()
+
+        # Test with a state that has outgoing transitions
+        transitions = self.representation.get_transitions_from_state(self.state0)
+        self.assertEqual(len(transitions), 1)
+        self.assertIn(self.action0, transitions)
+        self.assertIn(self.state1, transitions[self.action0])
+
+        # Test with a state that doesn't exist
+        nonexistent_state = StateRepresentation((Predicate(State, [State.ZERO]), Predicate(State, [State.ONE])))
+        transitions = self.representation.get_transitions_from_state(nonexistent_state)
+        self.assertEqual(len(transitions), 0)
+
+    def test_get_state_attributes(self):
+        """Test getting and setting state attributes."""
+        # Setup states with attributes
+        self.representation.add_states_from(
+            [self.state0, self.state1, self.state2, self.state3],
+            frequency=1,
+            probability=0.25,
+        )
+
+        # Test getting an attribute
+        attrs = self.representation.get_state_attributes("frequency")
+        self.assertEqual(len(attrs), 4)
+        self.assertEqual(attrs[self.state0], 1)
+        self.assertEqual(attrs[self.state1], 1)
+
+        # Test setting attributes
+        new_attrs = {self.state0: 10, self.state1: 20}
+        self.representation.set_state_attributes(new_attrs, "frequency")
+
+        # Verify attributes were updated
+        attrs = self.representation.get_state_attributes("frequency")
+        self.assertEqual(attrs[self.state0], 10)
+        self.assertEqual(attrs[self.state1], 20)
+        self.assertEqual(attrs[self.state2], 1)  # Unchanged
+
+    def test_get_outgoing_transitions(self):
+        """Test getting outgoing transitions from a state."""
+        # Setup states and transitions
+        self.setup_test_graph()
+
+        # Test without data
+        transitions = self.representation.get_outgoing_transitions(
+            self.state0, include_data=False
+        )
+        self.assertEqual(len(transitions), 1)
+
+        # Test with data
+        transitions = self.representation.get_outgoing_transitions(
+            self.state0, include_data=True
+        )
+        self.assertEqual(len(transitions), 1)
+        for _, _, data in transitions:
+            self.assertIn("action", data)
+            self.assertIn("frequency", data)
+            self.assertIn("probability", data)
+
+    def test_clear(self):
+        """Test clearing the representation."""
+        # Setup states and transitions
+        self.setup_test_graph()
+
+        # Verify setup
+        self.assertEqual(len(self.representation.get_all_states()), 4)
+        self.assertEqual(len(self.representation.get_all_transitions()), 4)
+
+        # Clear the representation
+        self.representation.clear()
+
+        # Verify clearing worked
+        self.assertEqual(len(self.representation.get_all_states()), 0)
+        self.assertEqual(len(self.representation.get_all_transitions()), 0)
+
+    def test_backward_compatibility(self):
+        """Test that the backward compatibility methods work correctly."""
+        # Setup states and transitions
+        self.setup_test_graph()
+
+        # Test old methods against new methods
+        self.assertEqual(
+            len(self.representation.nodes()), len(self.representation.get_all_states())
+        )
+        self.assertEqual(
+            len(self.representation.edges()),
+            len(self.representation.get_all_transitions()),
+        )
+        self.assertEqual(
+            len(self.representation.out_edges(self.state0)),
+            len(self.representation.get_outgoing_transitions(self.state0)),
+        )
+
+        # Test node attributes
+        old_attrs = self.representation.get_node_attributes("frequency")
+        new_attrs = self.representation.get_state_attributes("frequency")
+        self.assertEqual(old_attrs, new_attrs)
+
+        # Test edge data
+        old_data = self.representation.get_edge_data(
+            self.state0, self.state1, self.action0
+        )
+        new_data = self.representation.get_transition_data(
+            self.state0, self.state1, self.action0
+        )
+        self.assertEqual(old_data, new_data)
+
+    def test_simulation_with_environment(self):
+        """Test simulating a policy with the TestingEnv environment."""
+        # Create a fresh environment
+        env = TestingEnv()
+
+        # Create a representation and populate it
+        self.representation.clear()
+
+        # Add states
+        self.representation.add_states_from(
+            [self.state0, self.state1, self.state2, self.state3],
+            frequency=1,
+            probability=0.25,
+        )
+
+        # Add transitions that match the environment behavior
+        transitions: List[Tuple[StateRepresentation, StateRepresentation, Action]] = [
+            (self.state0, self.state1, self.action0),
+            (self.state1, self.state2, self.action0),
+            (self.state2, self.state3, self.action0),
+            (self.state3, self.state0, self.action0),
+        ]
+        self.representation.add_transitions_from(
+            transitions, frequency=1, probability=1.0
+        )
+
+        # Test simulation
+        obs, _ = env.reset()
+
+        # Check that the initial observation matches our discretization
+        initial_state = StateRepresentation(self.discretizer.discretize(obs))
+        self.assertEqual(initial_state, self.state0)
+
+        # Make one step and verify transition
+        state = initial_state
+        next_obs, _, _, _, _ = env.step(self.action0)
+        next_state = StateRepresentation(self.discretizer.discretize(next_obs))
+
+        # Check that the state transition is as expected
+        self.assertTrue(
+            self.representation.has_transition(state, next_state, self.action0)
+        )
+
+        # Get possible next states from representation
+        possible_next_states = self.representation.get_possible_next_states(
+            state, self.action0
+        )
+        self.assertIn(next_state, possible_next_states)
+
+    def setup_test_graph(self):
+        """Helper method to set up a test graph for multiple tests."""
+        # Clear any existing data
+        self.representation.clear()
+
+        # Add states
+        self.representation.add_states_from(
+            [self.state0, self.state1, self.state2, self.state3],
+            frequency=1,
+            probability=0.25,
+        )
+
+        # Add transitions - in TestingEnv, we can only do action 0 and it cycles through states
+        transitions: List[Tuple[StateRepresentation, StateRepresentation, Action]] = [
+            (self.state0, self.state1, self.action0),
+            (self.state1, self.state2, self.action0),
+            (self.state2, self.state3, self.action0),
+            (self.state3, self.state0, self.action0),
+        ]
+        self.representation.add_transitions_from(
+            transitions, frequency=1, probability=1.0
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/pgeon/test_policy_representation.py
+++ b/test/pgeon/test_policy_representation.py
@@ -3,10 +3,11 @@ from typing import Dict, Any, Tuple, cast, Optional, List
 
 import networkx as nx
 import numpy as np
+from torch import P
 
 from pgeon import GraphRepresentation, Predicate
 from test.domain.test_env import State, TestingDiscretizer, TestingEnv
-from pgeon.discretizer import StateRepresentation
+from pgeon.discretizer import PredicateBasedStateRepresentation, StateRepresentation
 from pgeon.policy_representation import Action
 
 
@@ -18,10 +19,10 @@ class TestPolicyRepresentation(unittest.TestCase):
         self.discretizer = TestingDiscretizer()
 
         # Create states and actions for testing
-        self.state0 = StateRepresentation((Predicate(State, [State.ZERO]),))
-        self.state1 = StateRepresentation((Predicate(State, [State.ONE]),))
-        self.state2 = StateRepresentation((Predicate(State, [State.TWO]),))
-        self.state3 = StateRepresentation((Predicate(State, [State.THREE]),))
+        self.state0 = PredicateBasedStateRepresentation((Predicate(State, [State.ZERO]),))
+        self.state1 = PredicateBasedStateRepresentation((Predicate(State, [State.ONE]),))
+        self.state2 = PredicateBasedStateRepresentation((Predicate(State, [State.TWO]),))
+        self.state3 = PredicateBasedStateRepresentation((Predicate(State, [State.THREE]),))
 
         self.action0: Action = 0
         self.representation = GraphRepresentation()
@@ -81,7 +82,7 @@ class TestPolicyRepresentation(unittest.TestCase):
         self.assertEqual(transition_data["action"], self.action0)
 
         # Add multiple transitions
-        transitions: List[Tuple[StateRepresentation, StateRepresentation, Action]] = [
+        transitions= [
             (self.state1, self.state2, self.action0),
             (self.state2, self.state3, self.action0),
             (self.state3, self.state0, self.action0),
@@ -115,7 +116,7 @@ class TestPolicyRepresentation(unittest.TestCase):
         self.assertEqual(len(actions), 1)
         self.assertIn(self.action0, actions)
 
-        nonexistent_state = StateRepresentation(
+        nonexistent_state = PredicateBasedStateRepresentation(
             (Predicate(State, [State.ZERO]), Predicate(State, [State.ONE]))
         )
         actions = self.representation.get_possible_actions(nonexistent_state)
@@ -135,7 +136,7 @@ class TestPolicyRepresentation(unittest.TestCase):
         self.assertEqual(len(next_states), 1)
         self.assertIn(self.state1, next_states)
 
-        nonexistent_state = StateRepresentation(
+        nonexistent_state = PredicateBasedStateRepresentation(
             (Predicate(State, [State.ZERO]), Predicate(State, [State.ONE]))
         )
         next_states = self.representation.get_possible_next_states(nonexistent_state)
@@ -150,7 +151,7 @@ class TestPolicyRepresentation(unittest.TestCase):
         self.assertIn(self.action0, transitions)
         self.assertIn(self.state1, transitions[self.action0])
 
-        nonexistent_state = StateRepresentation(
+        nonexistent_state = PredicateBasedStateRepresentation(
             (Predicate(State, [State.ZERO]), Predicate(State, [State.ONE]))
         )
         transitions = self.representation.get_transitions_from_state(nonexistent_state)
@@ -169,7 +170,7 @@ class TestPolicyRepresentation(unittest.TestCase):
         self.assertEqual(attrs[self.state0], 1)
         self.assertEqual(attrs[self.state1], 1)
 
-        new_attrs = {self.state0: 10, self.state1: 20}
+        new_attrs: Dict[StateRepresentation, int] = {self.state0: 10, self.state1: 20}
         self.representation.set_state_attributes(new_attrs, "frequency")
 
         attrs = self.representation.get_state_attributes("frequency")
@@ -257,12 +258,12 @@ class TestPolicyRepresentation(unittest.TestCase):
         )
 
         obs, _ = env.reset()
-        initial_state = StateRepresentation(self.discretizer.discretize(obs))
+        initial_state = PredicateBasedStateRepresentation(self.discretizer.discretize(obs))
         self.assertEqual(initial_state, self.state0)
 
         state = initial_state
         next_obs, _, _, _, _ = env.step(self.action0)
-        next_state = StateRepresentation(self.discretizer.discretize(next_obs))
+        next_state = PredicateBasedStateRepresentation(self.discretizer.discretize(next_obs))
 
         self.assertTrue(
             self.representation.has_transition(state, next_state, self.action0)

--- a/test/pgeon/test_policy_representation.py
+++ b/test/pgeon/test_policy_representation.py
@@ -1,9 +1,7 @@
 import unittest
-from typing import Dict, Any, Tuple, cast, Optional, List
+from typing import Dict, Tuple, List
 
 import networkx as nx
-import numpy as np
-from torch import P
 
 from pgeon import GraphRepresentation, Predicate
 from test.domain.test_env import State, TestingDiscretizer, TestingEnv

--- a/test/pgeon/test_policy_representation.py
+++ b/test/pgeon/test_policy_representation.py
@@ -17,10 +17,18 @@ class TestPolicyRepresentation(unittest.TestCase):
         self.discretizer = TestingDiscretizer()
 
         # Create states and actions for testing
-        self.state0 = PredicateBasedStateRepresentation((Predicate(State, [State.ZERO]),))
-        self.state1 = PredicateBasedStateRepresentation((Predicate(State, [State.ONE]),))
-        self.state2 = PredicateBasedStateRepresentation((Predicate(State, [State.TWO]),))
-        self.state3 = PredicateBasedStateRepresentation((Predicate(State, [State.THREE]),))
+        self.state0 = PredicateBasedStateRepresentation(
+            (Predicate(State, [State.ZERO]),)
+        )
+        self.state1 = PredicateBasedStateRepresentation(
+            (Predicate(State, [State.ONE]),)
+        )
+        self.state2 = PredicateBasedStateRepresentation(
+            (Predicate(State, [State.TWO]),)
+        )
+        self.state3 = PredicateBasedStateRepresentation(
+            (Predicate(State, [State.THREE]),)
+        )
 
         self.action0: Action = 0
         self.representation = GraphRepresentation()
@@ -80,7 +88,7 @@ class TestPolicyRepresentation(unittest.TestCase):
         self.assertEqual(transition_data["action"], self.action0)
 
         # Add multiple transitions
-        transitions= [
+        transitions = [
             (self.state1, self.state2, self.action0),
             (self.state2, self.state3, self.action0),
             (self.state3, self.state0, self.action0),
@@ -256,12 +264,16 @@ class TestPolicyRepresentation(unittest.TestCase):
         )
 
         obs, _ = env.reset()
-        initial_state = PredicateBasedStateRepresentation(self.discretizer.discretize(obs))
+        initial_state = PredicateBasedStateRepresentation(
+            self.discretizer.discretize(obs)
+        )
         self.assertEqual(initial_state, self.state0)
 
         state = initial_state
         next_obs, _, _, _, _ = env.step(self.action0)
-        next_state = PredicateBasedStateRepresentation(self.discretizer.discretize(next_obs))
+        next_state = PredicateBasedStateRepresentation(
+            self.discretizer.discretize(next_obs)
+        )
 
         self.assertTrue(
             self.representation.has_transition(state, next_state, self.action0)


### PR DESCRIPTION
## what changed
- split out `PolicyRepresentation` from `PolicyApproximator`
- reimplement core graph functionality from `PolicyGraph` in `GraphRepresentation`
  - use generic names like `state` and `transition`, as opposed to `node` and `edge`
  - add type checking
- add `test_policy_representation.py` with unit tests
- update `StateRepresentation` and `Action` in `discretizer.py`
- addresses #5 and #2 

## how it's tested
- unit tests are added to `test_policy_representation.py` (I recommend starting there when reviewing)

## notes
- some of the implementation details, I was unsure about. we should look closely at these later, especially as we integrate this into `PolicyApproximator`
- I left legacy methods like `nodes` and `edges` in `GraphRepresentation`, even though these are duplicates of the more general `states` and `transitions`. we could consider removing these already
- all type checks pass
- next steps:
  1. use this `PolicyRepresentation` in `PolicyApproximator`, when reimplementing `PolicyGraph` there
  2. update tests for `PolicyGraph` to point to `PolicyApproximator`