### PR TITLE
Implement PolicyApproximatorFromBasicObservation

### DIFF
--- a/src/pgeon/__init__.py
+++ b/src/pgeon/__init__.py
@@ -1,3 +1,5 @@
 from .policy_graph import *
-from .agent import Agent
-from .discretizer import Discretizer, Predicate
+from .agent import *
+from .discretizer import *
+from .policy_representation import *
+from .policy_approximator import *

--- a/src/pgeon/policy_approximator.py
+++ b/src/pgeon/policy_approximator.py
@@ -1,51 +1,37 @@
 import abc
-from typing import List, Any, Collection, Optional, Union, Tuple
+import random
+from collections import defaultdict
+from typing import (
+    List,
+    Any,
+    Optional,
+    Union,
+    Tuple,
+    Dict,
+    cast,
+)
 from gymnasium import Env
-from enum import Enum
+from enum import Enum, auto
+
+import numpy as np
+import tqdm
 
 from pgeon.agent import Agent
-from pgeon.discretizer import Discretizer, StateRepresentation
+from pgeon.discretizer import Discretizer, StateRepresentation, Action
 from pgeon.policy_representation import PolicyRepresentation
 
 
-class Base:
-    def __init__(self,
-                 discretizer: Discretizer,
-                 ):
-        super().__init__()
-        self.discretizer = discretizer
-
-        self._is_fit = False
-        self._trajectories_of_last_fit: List[List[Any]] = []
-
-    def fit(self):
-        ...
-
-
-# INTENTIONAL POLICY GRAPHS = BASE POLICY GRAPH + INTENTION FUNCTIONALITY
-
-
-
-
-class Desire:
-    ...
-
-
-class ProbabilityQuery:
-    ...
-
-
-class Action:
-    ...
+class Desire: ...
 
 
 class PolicyApproximator(abc.ABC):
-    def __init__(self,
-                 discretizer: Discretizer,
-                 policy_representation: PolicyRepresentation
-                 ):
+    def __init__(
+        self, discretizer: Discretizer, policy_representation: PolicyRepresentation
+    ):
         self.discretizer: Discretizer = discretizer
-        self.policy_represenation: PolicyRepresentation = policy_representation
+        self.policy_representation: PolicyRepresentation = policy_representation
+        self._is_fit = False
+        self._trajectories_of_last_fit: List[List[Any]] = []
 
     @abc.abstractmethod
     def save(self, format: str, path: Union[str, List[str]]):
@@ -53,95 +39,573 @@ class PolicyApproximator(abc.ABC):
         ...
 
     @abc.abstractmethod
-    def fit(self):
-        ...
+    def fit(self): ...
 
 
 # From agent and environment
-class OnlinePolicyApproximator(PolicyApproximator):
-    ...
+class OnlinePolicyApproximator(PolicyApproximator): ...
 
 
 # From trajectories
-class OfflinePolicyApproximator(PolicyApproximator):
-    ...
+class OfflinePolicyApproximator(PolicyApproximator): ...
 
 
 class PolicyApproximatorFromBasicObservation(OnlinePolicyApproximator):
-    def __init__(self,
-                 discretizer: Discretizer,
-                 policy_representation: PolicyRepresentation,
-                 environment: Env,
-                 agent: Agent
-                 ):
+    def __init__(
+        self,
+        discretizer: Discretizer,
+        policy_representation: PolicyRepresentation,
+        environment: Env,
+        agent: Agent,
+    ):
         super().__init__(discretizer, policy_representation)
         self.environment = environment
         self.agent = agent
 
-    def fit(self, n_episodes: int):
-        assert n_episodes > 0, "The number of episodes must be a positive integer number!"
+    def _run_episode(
+        self, agent: Agent, max_steps: Optional[int] = None, seed: Optional[int] = None
+    ) -> List[Any]:
+        observation, _ = self.environment.reset(seed=seed)
+        done = False
+        trajectory = [self.discretizer.discretize(observation)]
 
-        for ep_i in range(n_episodes):
+        step_counter = 0
+        while not done:
+            if max_steps is not None and step_counter >= max_steps:
+                break
 
-            episode_done = False
-            # Alternative, more space-efficient albeit slightly less readable trajectory representation in comments
-            episode_trajectory: List[Tuple[StateRepresentation, Action, StateRepresentation]] = []
-            # episode_trajectory: List[Union[StateRepresentation, Action]] = []
+            action = agent.act(observation)
+            observation, _, done, done2, _ = self.environment.step(action)
+            done = done or done2
 
-            state = self.environment.reset()
-            discretized_state = self.discretizer.discretize(state)
+            trajectory.extend([action, self.discretizer.discretize(observation)])
 
-            # episode_trajectory = [discretized_state]
+            step_counter += 1
 
-            while not episode_done:
-                action = self.agent.act(state)
+        return trajectory
 
-                # next_state, _, episode_done, _ = self.environment.step(action)
+    def _update_with_trajectory(self, trajectory: List[Any]) -> None:
+        # Only even numbers are states
+        states_in_trajectory = [
+            trajectory[i] for i in range(len(trajectory)) if i % 2 == 0
+        ]
+        all_new_states_in_trajectory = {
+            state
+            for state in set(states_in_trajectory)
+            if not self.policy_representation.has_state(state)
+        }
+        self.policy_representation.add_states_from(
+            all_new_states_in_trajectory, frequency=0
+        )
 
-                # discretized_next_state = self.discretizer.discretize(next_state)
-                # episode_trajectory.append((discretized_state, action, discretized_next_state))
-                # episode_trajectory.extend([action, discretized_next_state])
+        state_frequencies = {
+            s: states_in_trajectory.count(s) for s in set(states_in_trajectory)
+        }
 
-                # discretized_state = discretized_next_state
-                # TODO self.policy_represenation.update_representation(episode_trajectory)
-            # TODO Current pgeon version stores the episode trajectory (discretized states).
-            #      Consider whether we want to keep doing that.
+        states = self.policy_representation.get_all_states()
+        for state in state_frequencies:
+            for node in states:
+                if node == state:
+                    state_attrs = self.policy_representation.get_state_attributes(
+                        "frequency"
+                    )
+                    state_attrs[node] += state_frequencies[state]
+                    self.policy_representation.set_state_attributes(
+                        {node: state_attrs[node]}, "frequency"
+                    )
+                    break
 
-            # TODO May `self.policy_representation` perform any post-process?
+        pointer = 0
+        while (pointer + 1) < len(trajectory):
+            state_from, action, state_to = trajectory[pointer : pointer + 3]
+            if not self.policy_representation.has_transition(
+                state_from, state_to, action
+            ):
+                self.policy_representation.add_transition(
+                    state_from, state_to, action, frequency=0
+                )
 
-    def get_nearest_predicate(self, input_predicate: Tuple[Enum], verbose: bool = False):
-        """Returns the nearest predicate. If already exists, returns same predicate."""
-        raise NotImplementedError()
+            edge_data = self.policy_representation.get_transition_data(
+                state_from, state_to, action
+            )
+            if edge_data:
+                edge_data["frequency"] += 1
+            pointer += 2
 
-    def get_possible_actions(self, predicate):
-        """Get possible actions and probabilities for a predicate"""
-        raise NotImplementedError()
+    def _normalize(self) -> None:
+        weights = self.policy_representation.get_state_attributes("frequency")
+        total_frequency = sum([weights[state] for state in weights])
+        self.policy_representation.set_state_attributes(
+            {state: weights[state] / total_frequency for state in weights},
+            "probability",
+        )
 
-    def get_when_perform_action(self, action):
-        """When do you perform action X?"""
-        raise NotImplementedError()
+        for state in self.policy_representation.get_all_states():
+            transitions = self.policy_representation.get_outgoing_transitions(
+                state, include_data=True
+            )
+            total_frequency = 0
 
-    def question2(self, action, verbose: bool = False):
-        """When do you perform action X?"""
-        raise NotImplementedError()
+            for transition in transitions:
+                if len(transition) >= 3:  # Check if we have data
+                    _, _, data = transition
+                    if isinstance(data, dict) and "frequency" in data:
+                        total_frequency += data["frequency"]
 
-    def substract_predicates(self, origin, destination):
-        """Subtracts 2 predicates, getting only different values"""
-        raise NotImplementedError()
+            if total_frequency > 0:
+                for transition in transitions:
+                    if len(transition) >= 3:  # Check if we have data
+                        _, dest_state, data = transition
+                        if isinstance(data, dict) and "frequency" in data:
+                            action_val = data.get("action")
+                            if action_val is not None:
+                                edge_data = (
+                                    self.policy_representation.get_transition_data(
+                                        state, dest_state, action_val
+                                    )
+                                )
+                                if edge_data:
+                                    edge_data["probability"] = (
+                                        edge_data["frequency"] / total_frequency
+                                    )
 
-    def nearby_predicates(self, state, greedy: bool = False, verbose: bool = False):
-        """Gets nearby states from state"""
-        raise NotImplementedError()
+    def fit(
+        self,
+        n_episodes: int = 10,
+        max_steps: Optional[int] = None,
+        update: bool = False,
+    ) -> "PolicyApproximatorFromBasicObservation":
+        assert (
+            n_episodes > 0
+        ), "The number of episodes must be a positive integer number!"
 
-    def question3(self, predicate, action, greedy: bool = False, verbose: bool = False):
-        """Why do you perform action X in state Y?"""
-        raise NotImplementedError()
+        if not update:
+            self.policy_representation.clear()
+            self._trajectories_of_last_fit = []
+            self._is_fit = False
 
-    def get_most_probable_option(self, predicate, greedy: bool = False, verbose: bool = False):
-        """Get most probable action for a predicate"""
-        raise NotImplementedError()
+        progress_bar = tqdm.tqdm(range(n_episodes))
+        progress_bar.set_description("Fitting policy approximator...")
+        for ep in progress_bar:
+            trajectory_result: List[Any] = self._run_episode(
+                self.agent, max_steps=max_steps, seed=ep
+            )
+            self._update_with_trajectory(trajectory_result)
+            self._trajectories_of_last_fit.append(trajectory_result)
+
+        self._normalize()
+
+        self._is_fit = True
+
+        return self
+
+    def get_nearest_predicate(
+        self,
+        input_predicate: Union[StateRepresentation, Tuple[Enum, ...]],
+        verbose: bool = False,
+    ) -> StateRepresentation:
+        """Returns the nearest predicate on the representation. If already exists, then we return the same predicate. If not,
+        then tries to change the predicate to find a similar state (Maximum change: 1 value).
+        If we don't find a similar state, then we return None
+
+        :param input_predicate: Existent or non-existent predicate in the representation
+        :return: Nearest predicate
+        :param verbose: Prints additional information
+        """
+        # Predicate exists in the MDP
+        cast_predicate = cast(StateRepresentation, input_predicate)
+        if self.policy_representation.has_state(cast_predicate):
+            if verbose:
+                print("NEAREST PREDICATE of existing predicate:", input_predicate)
+            return cast_predicate
+        else:
+            if verbose:
+                print("NEAREST PREDICATE of NON existing predicate:", input_predicate)
+
+            predicate_space = self.discretizer.get_predicate_space()
+            # TODO: Implement distance function
+            new_pred = random.choice(predicate_space)
+            if verbose:
+                print("\tNEAREST PREDICATE in representation:", new_pred)
+            return cast(StateRepresentation, new_pred)
+
+    def get_possible_actions(
+        self, predicate: Union[StateRepresentation, Tuple[Enum, ...]]
+    ) -> List[Tuple[Any, float]]:
+        """Given a predicate, get the possible actions and it's probabilities
+
+        3 cases:
+
+        - Predicate not in representation but similar predicate found: Return actions of the similar predicate
+        - Predicate not in representation and no similar predicate found: Return all actions same probability
+        - Predicate in MDP: Return actions of the predicate in representation
+
+        :param predicate: Existing or not existing predicate
+        :return: Action probabilities of a given state
+        """
+        result = defaultdict(float)
+        cast_predicate = cast(StateRepresentation, predicate)
+
+        # Predicate not in representation
+        if not self.policy_representation.has_state(cast_predicate):
+            # Nearest predicate not found -> Random action
+            if cast_predicate is None:
+                result = {
+                    action: 1 / len(self.discretizer.all_actions())
+                    for action in self.discretizer.all_actions()
+                }
+                return sorted(result.items(), key=lambda x: x[1], reverse=True)
+
+            cast_predicate = self.get_nearest_predicate(cast_predicate)
+            if cast_predicate is None:
+                result = {
+                    a: 1 / len(self.discretizer.all_actions())
+                    for a in self.discretizer.all_actions()
+                }
+                return list(result.items())
+
+        # Out edges with actions
+        transitions = self.policy_representation.get_outgoing_transitions(
+            cast_predicate, include_data=True
+        )
+        possible_actions = []
+
+        for transition in transitions:
+            if len(transition) >= 3:  # Check if we have data
+                _, _, data = transition
+                if (
+                    isinstance(data, dict)
+                    and "action" in data
+                    and "probability" in data
+                ):
+                    action = data["action"]
+                    probability = data["probability"]
+                    possible_actions.append((cast_predicate, action, None, probability))
+
+        # Drop duplicated edges
+        possible_actions = list(set(possible_actions))
+        # Predicate has at least 1 out edge.
+        if len(possible_actions) > 0:
+            for _, action, _, weight in possible_actions:
+                all_actions = self.discretizer.all_actions()
+                if isinstance(action, int) and 0 <= action < len(all_actions):
+                    result[all_actions[action]] += weight
+            return sorted(result.items(), key=lambda x: x[1], reverse=True)
+        # Predicate does not have out edges. Then return all the actions with same probability
+        else:
+            result = {
+                a: 1 / len(self.discretizer.all_actions())
+                for a in self.discretizer.all_actions()
+            }
+            return list(result.items())
+
+    def question1(
+        self,
+        predicate: Union[StateRepresentation, Tuple[Enum, ...]],
+        verbose: bool = False,
+    ) -> List[Tuple[Any, float]]:
+        """
+        Answers the question: What actions would you take in state X?
+
+        :param predicate: The state to query
+        :param verbose: Whether to print verbose output
+        :return: List of (action, probability) tuples
+        """
+        possible_actions = self.get_possible_actions(predicate)
+        if verbose:
+            print("I will take one of these actions:")
+            for action, prob in possible_actions:
+                if hasattr(action, "name"):
+                    print("\t->", action.name, "\tProb:", round(prob * 100, 2), "%")
+                else:
+                    print("\t->", action, "\tProb:", round(prob * 100, 2), "%")
+        return possible_actions
+
+    def get_when_perform_action(
+        self, action: Action
+    ) -> Tuple[List[StateRepresentation], List[StateRepresentation]]:
+        """When do you perform action
+
+        :param action: Valid action
+        :return: A tuple of (all_states_with_action, states_where_action_is_best)
+        """
+        # Nodes where 'action' it's a possible action
+        # All the nodes that has the same action (It has repeated nodes)
+        all_transitions = self.policy_representation.get_all_transitions(
+            include_data=True
+        )
+        all_nodes = []
+
+        for transition in all_transitions:
+            if len(transition) >= 3:  # Check if we have data
+                u, _, data = transition
+                if (
+                    isinstance(data, dict)
+                    and "action" in data
+                    and data["action"] == action
+                ):
+                    all_nodes.append(u)
+
+        # Drop all the repeated nodes
+        all_nodes = list(set(all_nodes))
+
+        # Nodes where 'action' it's the most probable action
+        all_edges = []
+        for u in all_nodes:
+            out_edges = self.policy_representation.get_outgoing_transitions(
+                u, include_data=True
+            )
+            all_edges.append(out_edges)
+
+        all_best_actions = []
+        for edges in all_edges:
+            best_actions = []
+            for edge in edges:
+                if len(edge) >= 3:  # Check if we have data
+                    u, _, data = edge
+                    if (
+                        isinstance(data, dict)
+                        and "action" in data
+                        and "probability" in data
+                    ):
+                        best_actions.append((u, data["action"], data["probability"]))
+
+            if best_actions:
+                best_actions.sort(key=lambda x: x[2], reverse=True)
+                all_best_actions.append(best_actions[0])
+
+        best_nodes = [u for u, a, w in all_best_actions if a == action]
+
+        all_nodes.sort()
+        best_nodes.sort()
+        return all_nodes, best_nodes
+
+    def question2(
+        self, action: Action, verbose: bool = False
+    ) -> List[StateRepresentation]:
+        """
+        Answers the question: When do you perform action X?
+
+        :param action: The action to query
+        :param verbose: Whether to print verbose output
+        :return: List of states where the action is the most probable
+        """
+        if verbose:
+            print("*********************************")
+            print("* When do you perform action X?")
+            print("*********************************")
+
+        all_nodes, best_nodes = self.get_when_perform_action(action)
+        if verbose:
+            print(f"Most probable in {len(best_nodes)} states:")
+        for i in range(len(all_nodes)):
+            if i < len(best_nodes) and verbose:
+                print(f"\t-> {best_nodes[i]}")
+        # TODO: Extract common factors of resulting states
+        return best_nodes
+
+    def substract_predicates(
+        self,
+        origin: Union[str, List[str], StateRepresentation, Tuple[Enum, ...]],
+        destination: Union[str, List[str], StateRepresentation, Tuple[Enum, ...]],
+    ) -> Dict[str, Tuple[str, str]]:
+        """
+        Subtracts 2 predicates, getting only the values that are different
+
+        :param origin: Origin predicate
+        :param destination: Destination predicate
+        :return: Dict with the different values
+        """
+        origin_list: List[str] = []
+        destination_list: List[str] = []
+
+        if isinstance(origin, str):
+            origin_list = origin.split("-")
+        elif isinstance(origin, list):
+            origin_list = origin
+        elif isinstance(origin, tuple):
+            # Handle Tuple case
+            origin_list = [str(item) for item in origin]
+        else:
+            # Handle StateRepresentation case - convert to string first
+            origin_list = [str(origin)]
+
+        if isinstance(destination, str):
+            destination_list = destination.split("-")
+        elif isinstance(destination, list):
+            destination_list = destination
+        elif isinstance(destination, tuple):
+            # Handle Tuple case
+            destination_list = [str(item) for item in destination]
+        else:
+            # Handle StateRepresentation case - convert to string first
+            destination_list = [str(destination)]
+
+        result = {}
+        for value1, value2 in zip(origin_list, destination_list):
+            if value1 != value2:
+                result[value1] = (value1, value2)
+        return result
+
+    def nearby_predicates(
+        self,
+        state: Union[StateRepresentation, Tuple[Enum, ...]],
+        greedy: bool = False,
+        verbose: bool = False,
+    ) -> List[Tuple[Action, StateRepresentation, Dict[str, Tuple[str, str]]]]:
+        """
+        Gets nearby states from state
+
+        :param state: State to analyze
+        :param greedy: Whether to use greedy action selection
+        :param verbose: Whether to print verbose output
+        :return: List of [Action, destination_state, difference]
+        """
+        cast_state = cast(StateRepresentation, state)
+        out_edges = self.policy_representation.get_outgoing_transitions(
+            cast_state, include_data=True
+        )
+        outs = []
+
+        for edge in out_edges:
+            if len(edge) >= 3:  # Check if we have data
+                u, v, d = edge
+                if isinstance(d, dict) and "action" in d and "probability" in d:
+                    outs.append((u, v, d["action"], d["probability"]))
+
+        result = []
+        for u, v, a, w in outs:
+            most_probable = self.get_most_probable_option(
+                v, greedy=greedy, verbose=verbose
+            )
+            if most_probable:
+                result.append((most_probable, v, self.substract_predicates(u, v)))
+
+        result = sorted(result, key=lambda x: x[1])
+        return result
+
+    def get_most_probable_option(
+        self,
+        predicate: Union[StateRepresentation, Tuple[Enum, ...]],
+        greedy: bool = False,
+        verbose: bool = False,
+    ) -> Optional[Action]:
+        """
+        Get most probable action for a predicate
+
+        :param predicate: The state to query
+        :param greedy: Whether to use greedy action selection
+        :param verbose: Whether to print verbose output
+        :return: The most probable action or None
+        """
+        cast_predicate = cast(StateRepresentation, predicate)
+        if greedy:
+            nearest_predicate = self.get_nearest_predicate(
+                cast_predicate, verbose=verbose
+            )
+            possible_actions = self.get_possible_actions(nearest_predicate)
+
+            # Possible actions always will have 1 element since for each state we only save the best action
+            if possible_actions:
+                return possible_actions[0][0]
+            return None
+        else:
+            nearest_predicate = self.get_nearest_predicate(
+                cast_predicate, verbose=verbose
+            )
+            possible_actions = self.get_possible_actions(nearest_predicate)
+            if possible_actions:
+                possible_actions = sorted(possible_actions, key=lambda x: x[1])
+                return possible_actions[-1][0]
+            return None
+
+    def question3(
+        self,
+        predicate: Union[StateRepresentation, Tuple[Enum, ...]],
+        action: Action,
+        greedy: bool = False,
+        verbose: bool = False,
+    ) -> List[Dict[str, Tuple[str, str]]]:
+        """
+        Answers the question: Why do you perform action X in state Y?
+
+        :param predicate: The state to query
+        :param action: The action to query
+        :param greedy: Whether to use greedy action selection
+        :param verbose: Whether to print verbose output
+        :return: List of explanations as dictionaries
+        """
+        if verbose:
+            print("***********************************************")
+            print("* Why did not you perform X action in Y state?")
+            print("***********************************************")
+
+        # Need to define appropriate policy modes for this function
+        class PGBasedPolicyMode(Enum):
+            GREEDY = auto()
+            STOCHASTIC = auto()
+
+        # This is a simplified version without the actual policy class
+        if greedy:
+            mode = PGBasedPolicyMode.GREEDY
+        else:
+            mode = PGBasedPolicyMode.STOCHASTIC
+
+        # Determine best action based on mode
+        if mode == PGBasedPolicyMode.GREEDY:
+            possible_actions = self.get_possible_actions(predicate)
+            if possible_actions:
+                best_action = possible_actions[0][0]
+            else:
+                best_action = None
+        else:
+            possible_actions = self.get_possible_actions(predicate)
+            if possible_actions:
+                actions, probs = zip(*possible_actions)
+                best_action = np.random.choice(actions, p=probs)
+            else:
+                best_action = None
+
+        result = self.nearby_predicates(predicate)
+        explanations = []
+
+        if verbose:
+            print("I would have chosen:", best_action)
+            print(f"I would have chosen {action} under the following conditions:")
+        for a, v, diff in result:
+            # Only if performs the input action
+            if a == action:
+                if verbose:
+                    print(f"Hypothetical state: {v}")
+                    for predicate_key, predicate_value in diff.items():
+                        print(
+                            f"   Actual: {predicate_key} = {predicate_value[0]} -> Counterfactual: {predicate_key} = {predicate_value[1]}"
+                        )
+                explanations.append(diff)
+        if len(explanations) == 0 and verbose:
+            print("\tI don't know where I would have ended up")
+        return explanations
+
+    def save(self, format: str, path: Union[str, List[str]]):
+        """
+        Save the policy approximator
+
+        :param format: The format to save in (e.g., 'json', 'pickle')
+        :param path: The path to save to
+        """
+        if not self._is_fit:
+            raise Exception("Policy approximator cannot be saved before fitting!")
+
+        # Implement appropriate save functionality based on the format
+        if format == "json":
+            # Implement JSON serialization
+            pass
+        elif format == "pickle":
+            # Implement pickle serialization
+            pass
+        else:
+            raise NotImplementedError(f"Format {format} not supported for saving")
 
 
 class InterventionalPGConstruction(PolicyApproximator):
-    def fit(self):
-        ...
+    def fit(self): ...

--- a/src/pgeon/policy_approximator.py
+++ b/src/pgeon/policy_approximator.py
@@ -51,6 +51,10 @@ class OfflinePolicyApproximator(PolicyApproximator): ...
 
 
 class PolicyApproximatorFromBasicObservation(OnlinePolicyApproximator):
+    """
+    Policy approximator that approximates the policy from basic observations,
+    given an agent and an environment.
+    """
     def __init__(
         self,
         discretizer: Discretizer,

--- a/test/domain/test_env.py
+++ b/test/domain/test_env.py
@@ -1,5 +1,5 @@
 from enum import auto, Enum
-from typing import Tuple, Any, SupportsFloat
+from typing import Tuple, Any, SupportsFloat, List
 
 import gymnasium
 import numpy as np
@@ -65,7 +65,7 @@ class TestingDiscretizer(Discretizer):
     def all_actions(self):
         return [0]
 
-    def get_predicate_space(self):
+    def get_predicate_space(self) -> List[Tuple[Predicate, ...]]:
         ...
 
     def nearest_state(self, state):

--- a/test/pgeon/test_ask_questions_to_graph.py
+++ b/test/pgeon/test_ask_questions_to_graph.py
@@ -3,6 +3,7 @@ import unittest
 import gymnasium
 
 from pgeon import PolicyGraph, Predicate
+from pgeon.discretizer import PredicateBasedStateRepresentation
 from test.domain.cartpole import CartpoleDiscretizer, Position, Velocity, Angle, Action
 
 
@@ -16,7 +17,7 @@ class TestAskQuestionsToGraph(unittest.TestCase):
 
     def test_question_1(self):
         result = self.pg_cartpole.question1(
-            (Predicate(Position, [Position.MIDDLE]), Predicate(Velocity, [Velocity.LEFT]), Predicate(Angle, [Angle.STABILIZING_RIGHT]))
+            PredicateBasedStateRepresentation((Predicate(Position, [Position.MIDDLE]), Predicate(Velocity, [Velocity.LEFT]), Predicate(Angle, [Angle.STABILIZING_RIGHT])))
         )
 
         self.assertEqual(len(result), 2)
@@ -43,7 +44,7 @@ class TestAskQuestionsToGraph(unittest.TestCase):
 
     def test_question_1_no_nearest_predicate(self):
         result = self.pg_cartpole.question1(
-            (Predicate(Position, [Position.RIGHT]), Predicate(Velocity, [Velocity.RIGHT]), Predicate(Angle, [Angle.STUCK_LEFT]))
+            PredicateBasedStateRepresentation((Predicate(Position, [Position.RIGHT]), Predicate(Velocity, [Velocity.RIGHT]), Predicate(Angle, [Angle.STUCK_LEFT])))
         )
 
         self.assertEqual(len(result), 2)

--- a/test/pgeon/test_policy_approximator.py
+++ b/test/pgeon/test_policy_approximator.py
@@ -13,18 +13,15 @@ class TestPolicyApproximator(unittest.TestCase):
     """
 
     def setUp(self):
-        """Set up test environment, discretizer, and policy representation."""
         self.env = TestingEnv()
         self.discretizer = TestingDiscretizer()
         self.representation = GraphRepresentation()
         self.agent = TestingAgent()
 
-        # Initialize the policy approximator
         self.approximator = PolicyApproximatorFromBasicObservation(
             self.discretizer, self.representation, self.env, self.agent
         )
 
-        # Create states and actions for testing
         self.state0 = PredicateBasedStateRepresentation(
             (Predicate(State, [State.ZERO]),)
         )
@@ -38,10 +35,8 @@ class TestPolicyApproximator(unittest.TestCase):
             (Predicate(State, [State.THREE]),)
         )
 
-        # TestingEnv only supports action 0
-        self.action0: Action = 0  # type: ignore
+        self.action0: Action = 0
 
-        # Patch the get_predicate_space method in the discretizer for testing
         self.original_get_predicate_space = self.discretizer.get_predicate_space
         self.discretizer.get_predicate_space = lambda: [
             (Predicate(State, [State.ZERO]),),
@@ -51,11 +46,9 @@ class TestPolicyApproximator(unittest.TestCase):
         ]
 
     def tearDown(self):
-        """Restore the original get_predicate_space method."""
         self.discretizer.get_predicate_space = self.original_get_predicate_space
 
     def test_initialization(self):
-        """Test initialization of policy approximator."""
         self.assertEqual(self.approximator.discretizer, self.discretizer)
         self.assertEqual(self.approximator.policy_representation, self.representation)
         self.assertEqual(self.approximator.environment, self.env)
@@ -64,14 +57,10 @@ class TestPolicyApproximator(unittest.TestCase):
         self.assertEqual(self.approximator._trajectories_of_last_fit, [])
 
     def test_fit(self):
-        """Test fitting the policy approximator."""
-        # Fit the approximator with 1 episode
         self.approximator.fit(n_episodes=1)
 
-        # Verify the approximator is fit
         self.assertTrue(self.approximator._is_fit)
 
-        # Check that states were added to the representation
         states = self.representation.get_all_states()
         self.assertEqual(len(states), 4)
         self.assertIn(self.state0, states)
@@ -79,7 +68,6 @@ class TestPolicyApproximator(unittest.TestCase):
         self.assertIn(self.state2, states)
         self.assertIn(self.state3, states)
 
-        # Check that transitions were added
         self.assertTrue(
             self.representation.has_transition(self.state0, self.state1, self.action0)
         )
@@ -93,69 +81,48 @@ class TestPolicyApproximator(unittest.TestCase):
             self.representation.has_transition(self.state3, self.state0, self.action0)
         )
 
-        # Check transition counts
         transitions = self.representation.get_all_transitions(include_data=True)
         for transition in transitions:
             from_state, to_state, data = transition
             if isinstance(data, dict) and "frequency" in data:
-                # Each transition should have been observed at least once
                 self.assertGreater(data["frequency"], 0)
-
-                # Probability should be set
                 self.assertIn("probability", data)
                 self.assertGreater(data["probability"], 0)
                 self.assertLessEqual(data["probability"], 1.0)
 
     def test_get_possible_actions(self):
-        """Test getting possible actions from a state."""
-        # Fit the approximator
         self.approximator.fit(n_episodes=1)
 
-        # Test with a state that has outgoing transitions
         possible_actions = self.approximator.get_possible_actions(self.state0)
-        self.assertEqual(len(possible_actions), 1)  # Only one action (0) in TestingEnv
+        self.assertEqual(len(possible_actions), 1)
 
-        # The first item should be a tuple (action, probability)
         action, prob = possible_actions[0]
-        self.assertEqual(action, 0)  # The action from TestingEnv.all_actions()
-        self.assertEqual(
-            prob, 1.0
-        )  # Probability should be 1.0 since there's only one possible action
+        self.assertEqual(action, 0)
+        self.assertEqual(prob, 1.0)
 
-        # Test with a state that doesn't exist in the representation
         nonexistent_state = PredicateBasedStateRepresentation(
             (Predicate(State, [State.ZERO]), Predicate(State, [State.ONE]))
         )
         possible_actions = self.approximator.get_possible_actions(nonexistent_state)
-        self.assertEqual(
-            len(possible_actions), 1
-        )  # Should return one action with equal probability
-        self.assertEqual(possible_actions[0][0], 0)  # Should be action 0
-        self.assertEqual(possible_actions[0][1], 1.0)  # Probability should be 1.0
+        self.assertEqual(len(possible_actions), 1)
+        self.assertEqual(possible_actions[0][0], 0)
+        self.assertEqual(possible_actions[0][1], 1.0)
 
     def test_get_nearest_predicate(self):
-        """Test getting the nearest predicate."""
-        # Fit the approximator
         self.approximator.fit(n_episodes=1)
 
-        # Test with a state that exists
         nearest = self.approximator.get_nearest_predicate(self.state0)
         self.assertEqual(nearest, self.state0)
 
-        # Test with a state that doesn't exist
         nonexistent_state = PredicateBasedStateRepresentation(
             (Predicate(State, [State.ZERO]), Predicate(State, [State.ONE]))
         )
         nearest = self.approximator.get_nearest_predicate(nonexistent_state)
-        # The result should be a state in the representation
         self.assertIn(nearest, [self.state0, self.state1, self.state2, self.state3])
 
     def test_question1(self):
-        """Test the question1 method (what actions would you take in state X?)."""
-        # Fit the approximator
         self.approximator.fit(n_episodes=1)
 
-        # Test with a state that has outgoing transitions
         result = self.approximator.question1(self.state0)
         self.assertEqual(len(result), 1)
         action, prob = result[0]
@@ -163,13 +130,9 @@ class TestPolicyApproximator(unittest.TestCase):
         self.assertEqual(prob, 1.0)
 
     def test_question2(self):
-        """Test the question2 method (when do you perform action X?)."""
-        # Fit the approximator
         self.approximator.fit(n_episodes=1)
 
-        # Test with action 0
         best_nodes = self.approximator.question2(self.action0)
-        # All states should be best for action 0 since it's the only action
         self.assertEqual(len(best_nodes), 4)
         self.assertIn(self.state0, best_nodes)
         self.assertIn(self.state1, best_nodes)
@@ -177,29 +140,20 @@ class TestPolicyApproximator(unittest.TestCase):
         self.assertIn(self.state3, best_nodes)
 
     def test_question3(self):
-        """Test the question3 method (why do you perform action X in state Y?)."""
-        # Fit the approximator
         self.approximator.fit(n_episodes=1)
 
-        # Test with state0 and action0
         explanations = self.approximator.question3(self.state0, self.action0)
-        # In our simple environment, there's only one action, so this should be empty
-        # as there are no alternative actions to explain
         self.assertEqual(len(explanations), 0)
 
     def test_creating_graph_representation_programmatically(self):
-        """Test creating a graph representation programmatically."""
-        # Clear any existing data
         self.representation.clear()
 
-        # Add states
         self.representation.add_states_from(
             [self.state0, self.state1, self.state2, self.state3],
             frequency=1,
             probability=0.25,
         )
 
-        # Add transitions
         transitions = [
             (self.state0, self.state1, self.action0),
             (self.state1, self.state2, self.action0),
@@ -210,16 +164,14 @@ class TestPolicyApproximator(unittest.TestCase):
             transitions, frequency=1, probability=1.0
         )
 
-        # Verify the structure
         self.assertEqual(len(self.representation.get_all_states()), 4)
         self.assertEqual(len(self.representation.get_all_transitions()), 4)
 
-        # Create a new approximator with this representation
+        # Set up a new approximator with the graph representation
         approx = PolicyApproximatorFromBasicObservation(
             self.discretizer, self.representation, self.env, self.agent
         )
 
-        # Test that we can query the approximator with our manually created representation
         result = approx.question1(self.state0)
         self.assertEqual(len(result), 1)
         action, prob = result[0]

--- a/test/pgeon/test_policy_approximator.py
+++ b/test/pgeon/test_policy_approximator.py
@@ -1,0 +1,224 @@
+import unittest
+from typing import Dict, Any, Tuple, cast, Optional, List, Type, Sequence
+
+import networkx as nx
+import numpy as np
+from enum import Enum
+
+from pgeon import GraphRepresentation, Predicate
+from pgeon.policy_approximator import PolicyApproximatorFromBasicObservation
+from test.domain.test_env import State, TestingDiscretizer, TestingEnv, TestingAgent
+from pgeon.discretizer import StateRepresentation
+from pgeon.policy_representation import Action
+
+
+class TestPolicyApproximator(unittest.TestCase):
+    """
+    Tests for the PolicyApproximatorFromBasicObservation class using GraphRepresentation.
+    """
+
+    def setUp(self):
+        """Set up test environment, discretizer, and policy representation."""
+        self.env = TestingEnv()
+        self.discretizer = TestingDiscretizer()
+        self.representation = GraphRepresentation()
+        self.agent = TestingAgent()
+
+        # Initialize the policy approximator
+        self.approximator = PolicyApproximatorFromBasicObservation(
+            self.discretizer, self.representation, self.env, self.agent
+        )
+
+        # Create states and actions for testing
+        self.state0 = StateRepresentation((Predicate(State, [State.ZERO]),))
+        self.state1 = StateRepresentation((Predicate(State, [State.ONE]),))
+        self.state2 = StateRepresentation((Predicate(State, [State.TWO]),))
+        self.state3 = StateRepresentation((Predicate(State, [State.THREE]),))
+
+        # TestingEnv only supports action 0
+        self.action0: Action = 0  # type: ignore
+
+        # Patch the get_predicate_space method in the discretizer for testing
+        self.original_get_predicate_space = self.discretizer.get_predicate_space
+        self.discretizer.get_predicate_space = lambda: [
+            (Predicate(State, [State.ZERO]),),
+            (Predicate(State, [State.ONE]),),
+            (Predicate(State, [State.TWO]),),
+            (Predicate(State, [State.THREE]),),
+        ]
+
+    def tearDown(self):
+        """Restore the original get_predicate_space method."""
+        self.discretizer.get_predicate_space = self.original_get_predicate_space
+
+    def test_initialization(self):
+        """Test initialization of policy approximator."""
+        self.assertEqual(self.approximator.discretizer, self.discretizer)
+        self.assertEqual(self.approximator.policy_representation, self.representation)
+        self.assertEqual(self.approximator.environment, self.env)
+        self.assertEqual(self.approximator.agent, self.agent)
+        self.assertFalse(self.approximator._is_fit)
+        self.assertEqual(self.approximator._trajectories_of_last_fit, [])
+
+    def test_fit(self):
+        """Test fitting the policy approximator."""
+        # Fit the approximator with 1 episode
+        self.approximator.fit(n_episodes=1)
+
+        # Verify the approximator is fit
+        self.assertTrue(self.approximator._is_fit)
+
+        # Check that states were added to the representation
+        states = self.representation.get_all_states()
+        self.assertEqual(len(states), 4)
+        self.assertIn(self.state0, states)
+        self.assertIn(self.state1, states)
+        self.assertIn(self.state2, states)
+        self.assertIn(self.state3, states)
+
+        # Check that transitions were added
+        self.assertTrue(
+            self.representation.has_transition(self.state0, self.state1, self.action0)
+        )
+        self.assertTrue(
+            self.representation.has_transition(self.state1, self.state2, self.action0)
+        )
+        self.assertTrue(
+            self.representation.has_transition(self.state2, self.state3, self.action0)
+        )
+        self.assertTrue(
+            self.representation.has_transition(self.state3, self.state0, self.action0)
+        )
+
+        # Check transition counts
+        transitions = self.representation.get_all_transitions(include_data=True)
+        for transition in transitions:
+            from_state, to_state, data = transition
+            if isinstance(data, dict) and "frequency" in data:
+                # Each transition should have been observed at least once
+                self.assertGreater(data["frequency"], 0)
+
+                # Probability should be set
+                self.assertIn("probability", data)
+                self.assertGreater(data["probability"], 0)
+                self.assertLessEqual(data["probability"], 1.0)
+
+    def test_get_possible_actions(self):
+        """Test getting possible actions from a state."""
+        # Fit the approximator
+        self.approximator.fit(n_episodes=1)
+
+        # Test with a state that has outgoing transitions
+        possible_actions = self.approximator.get_possible_actions(self.state0)
+        self.assertEqual(len(possible_actions), 1)  # Only one action (0) in TestingEnv
+
+        # The first item should be a tuple (action, probability)
+        action, prob = possible_actions[0]
+        self.assertEqual(action, 0)  # The action from TestingEnv.all_actions()
+        self.assertEqual(
+            prob, 1.0
+        )  # Probability should be 1.0 since there's only one possible action
+
+        # Test with a state that doesn't exist in the representation
+        nonexistent_state = StateRepresentation((Predicate(State, [State.ZERO]), Predicate(State, [State.ONE])))
+        possible_actions = self.approximator.get_possible_actions(nonexistent_state)
+        self.assertEqual(
+            len(possible_actions), 1
+        )  # Should return one action with equal probability
+        self.assertEqual(possible_actions[0][0], 0)  # Should be action 0
+        self.assertEqual(possible_actions[0][1], 1.0)  # Probability should be 1.0
+
+    def test_get_nearest_predicate(self):
+        """Test getting the nearest predicate."""
+        # Fit the approximator
+        self.approximator.fit(n_episodes=1)
+
+        # Test with a state that exists
+        nearest = self.approximator.get_nearest_predicate(self.state0)
+        self.assertEqual(nearest, self.state0)
+
+        # Test with a state that doesn't exist
+        nonexistent_state = StateRepresentation((Predicate(State, [State.ZERO]), Predicate(State, [State.ONE])))
+        nearest = self.approximator.get_nearest_predicate(nonexistent_state)
+        # The result should be a state in the representation
+        self.assertIn(nearest, [self.state0, self.state1, self.state2, self.state3])
+
+    def test_question1(self):
+        """Test the question1 method (what actions would you take in state X?)."""
+        # Fit the approximator
+        self.approximator.fit(n_episodes=1)
+
+        # Test with a state that has outgoing transitions
+        result = self.approximator.question1(self.state0)
+        self.assertEqual(len(result), 1)
+        action, prob = result[0]
+        self.assertEqual(action, 0)
+        self.assertEqual(prob, 1.0)
+
+    def test_question2(self):
+        """Test the question2 method (when do you perform action X?)."""
+        # Fit the approximator
+        self.approximator.fit(n_episodes=1)
+
+        # Test with action 0
+        best_nodes = self.approximator.question2(self.action0)
+        # All states should be best for action 0 since it's the only action
+        self.assertEqual(len(best_nodes), 4)
+        self.assertIn(self.state0, best_nodes)
+        self.assertIn(self.state1, best_nodes)
+        self.assertIn(self.state2, best_nodes)
+        self.assertIn(self.state3, best_nodes)
+
+    def test_question3(self):
+        """Test the question3 method (why do you perform action X in state Y?)."""
+        # Fit the approximator
+        self.approximator.fit(n_episodes=1)
+
+        # Test with state0 and action0
+        explanations = self.approximator.question3(self.state0, self.action0)
+        # In our simple environment, there's only one action, so this should be empty
+        # as there are no alternative actions to explain
+        self.assertEqual(len(explanations), 0)
+
+    def test_creating_graph_representation_programmatically(self):
+        """Test creating a graph representation programmatically."""
+        # Clear any existing data
+        self.representation.clear()
+
+        # Add states
+        self.representation.add_states_from(
+            [self.state0, self.state1, self.state2, self.state3],
+            frequency=1,
+            probability=0.25,
+        )
+
+        # Add transitions
+        transitions = [
+            (self.state0, self.state1, self.action0),
+            (self.state1, self.state2, self.action0),
+            (self.state2, self.state3, self.action0),
+            (self.state3, self.state0, self.action0),
+        ]
+        self.representation.add_transitions_from(
+            transitions, frequency=1, probability=1.0
+        )
+
+        # Verify the structure
+        self.assertEqual(len(self.representation.get_all_states()), 4)
+        self.assertEqual(len(self.representation.get_all_transitions()), 4)
+
+        # Create a new approximator with this representation
+        approx = PolicyApproximatorFromBasicObservation(
+            self.discretizer, self.representation, self.env, self.agent
+        )
+
+        # Test that we can query the approximator with our manually created representation
+        result = approx.question1(self.state0)
+        self.assertEqual(len(result), 1)
+        action, prob = result[0]
+        self.assertEqual(action, 0)
+        self.assertEqual(prob, 1.0)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/pgeon/test_policy_approximator.py
+++ b/test/pgeon/test_policy_approximator.py
@@ -1,14 +1,9 @@
 import unittest
-from typing import Dict, Any, Tuple, cast, Optional, List, Type, Sequence
-
-import networkx as nx
-import numpy as np
-from enum import Enum
 
 from pgeon import GraphRepresentation, Predicate
 from pgeon.policy_approximator import PolicyApproximatorFromBasicObservation
 from test.domain.test_env import State, TestingDiscretizer, TestingEnv, TestingAgent
-from pgeon.discretizer import StateRepresentation
+from pgeon.discretizer import PredicateBasedStateRepresentation
 from pgeon.policy_representation import Action
 
 
@@ -30,10 +25,10 @@ class TestPolicyApproximator(unittest.TestCase):
         )
 
         # Create states and actions for testing
-        self.state0 = StateRepresentation((Predicate(State, [State.ZERO]),))
-        self.state1 = StateRepresentation((Predicate(State, [State.ONE]),))
-        self.state2 = StateRepresentation((Predicate(State, [State.TWO]),))
-        self.state3 = StateRepresentation((Predicate(State, [State.THREE]),))
+        self.state0 = PredicateBasedStateRepresentation((Predicate(State, [State.ZERO]),))
+        self.state1 = PredicateBasedStateRepresentation((Predicate(State, [State.ONE]),))
+        self.state2 = PredicateBasedStateRepresentation((Predicate(State, [State.TWO]),))
+        self.state3 = PredicateBasedStateRepresentation((Predicate(State, [State.THREE]),))
 
         # TestingEnv only supports action 0
         self.action0: Action = 0  # type: ignore
@@ -120,7 +115,7 @@ class TestPolicyApproximator(unittest.TestCase):
         )  # Probability should be 1.0 since there's only one possible action
 
         # Test with a state that doesn't exist in the representation
-        nonexistent_state = StateRepresentation((Predicate(State, [State.ZERO]), Predicate(State, [State.ONE])))
+        nonexistent_state = PredicateBasedStateRepresentation((Predicate(State, [State.ZERO]), Predicate(State, [State.ONE])))
         possible_actions = self.approximator.get_possible_actions(nonexistent_state)
         self.assertEqual(
             len(possible_actions), 1
@@ -138,7 +133,7 @@ class TestPolicyApproximator(unittest.TestCase):
         self.assertEqual(nearest, self.state0)
 
         # Test with a state that doesn't exist
-        nonexistent_state = StateRepresentation((Predicate(State, [State.ZERO]), Predicate(State, [State.ONE])))
+        nonexistent_state = PredicateBasedStateRepresentation((Predicate(State, [State.ZERO]), Predicate(State, [State.ONE])))
         nearest = self.approximator.get_nearest_predicate(nonexistent_state)
         # The result should be a state in the representation
         self.assertIn(nearest, [self.state0, self.state1, self.state2, self.state3])

--- a/test/pgeon/test_policy_approximator.py
+++ b/test/pgeon/test_policy_approximator.py
@@ -25,10 +25,18 @@ class TestPolicyApproximator(unittest.TestCase):
         )
 
         # Create states and actions for testing
-        self.state0 = PredicateBasedStateRepresentation((Predicate(State, [State.ZERO]),))
-        self.state1 = PredicateBasedStateRepresentation((Predicate(State, [State.ONE]),))
-        self.state2 = PredicateBasedStateRepresentation((Predicate(State, [State.TWO]),))
-        self.state3 = PredicateBasedStateRepresentation((Predicate(State, [State.THREE]),))
+        self.state0 = PredicateBasedStateRepresentation(
+            (Predicate(State, [State.ZERO]),)
+        )
+        self.state1 = PredicateBasedStateRepresentation(
+            (Predicate(State, [State.ONE]),)
+        )
+        self.state2 = PredicateBasedStateRepresentation(
+            (Predicate(State, [State.TWO]),)
+        )
+        self.state3 = PredicateBasedStateRepresentation(
+            (Predicate(State, [State.THREE]),)
+        )
 
         # TestingEnv only supports action 0
         self.action0: Action = 0  # type: ignore
@@ -115,7 +123,9 @@ class TestPolicyApproximator(unittest.TestCase):
         )  # Probability should be 1.0 since there's only one possible action
 
         # Test with a state that doesn't exist in the representation
-        nonexistent_state = PredicateBasedStateRepresentation((Predicate(State, [State.ZERO]), Predicate(State, [State.ONE])))
+        nonexistent_state = PredicateBasedStateRepresentation(
+            (Predicate(State, [State.ZERO]), Predicate(State, [State.ONE]))
+        )
         possible_actions = self.approximator.get_possible_actions(nonexistent_state)
         self.assertEqual(
             len(possible_actions), 1
@@ -133,7 +143,9 @@ class TestPolicyApproximator(unittest.TestCase):
         self.assertEqual(nearest, self.state0)
 
         # Test with a state that doesn't exist
-        nonexistent_state = PredicateBasedStateRepresentation((Predicate(State, [State.ZERO]), Predicate(State, [State.ONE])))
+        nonexistent_state = PredicateBasedStateRepresentation(
+            (Predicate(State, [State.ZERO]), Predicate(State, [State.ONE]))
+        )
         nearest = self.approximator.get_nearest_predicate(nonexistent_state)
         # The result should be a state in the representation
         self.assertIn(nearest, [self.state0, self.state1, self.state2, self.state3])

--- a/test/pgeon/test_policy_representation.py
+++ b/test/pgeon/test_policy_representation.py
@@ -2,8 +2,8 @@ import unittest
 from typing import Dict, Tuple, List
 
 import networkx as nx
-from pgeon import GraphRepresentation, Predicate
 
+from pgeon import GraphRepresentation, Predicate
 from test.domain.test_env import State, TestingDiscretizer, TestingEnv
 from pgeon.discretizer import PredicateBasedStateRepresentation, StateRepresentation
 from pgeon.policy_representation import Action

--- a/test/pgeon/test_policy_representation.py
+++ b/test/pgeon/test_policy_representation.py
@@ -2,8 +2,8 @@ import unittest
 from typing import Dict, Tuple, List
 
 import networkx as nx
-
 from pgeon import GraphRepresentation, Predicate
+
 from test.domain.test_env import State, TestingDiscretizer, TestingEnv
 from pgeon.discretizer import PredicateBasedStateRepresentation, StateRepresentation
 from pgeon.policy_representation import Action


### PR DESCRIPTION
## what changed
- copy the business logic of `PolicyGraph` to `PolicyApproximatorFromBasicObservation`
- use the `PolicyRepresentation` member to store and query the graph
- add `test_policy_approximator.py` with fundamental tests (initialization, copying, fitting a single episode)

## testing
- add `test_policy_approximator.py`
  - `test_initialization`
  - `test_fit`
  - `test_get_possible_actions`
  - `test_get_nearest_predicate`
  - `test_question1`
  - `test_question2`
  - `test_question3`
  - `test_creating_graph_representation_programmatically`
    - as if from a trajectory