### PR TITLE
Add --ignore-init-module-imports flag to autoflake pre-commit hook, revert src/pgeon/__init__.py

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -24,4 +24,4 @@ repos:
     rev: v2.3.1
     hooks:
     -   id: autoflake
-        args: [--remove-all-unused-imports, --in-place]
+        args: [--remove-all-unused-imports, --ignore-init-module-imports, --in-place]

--- a/src/pgeon/__init__.py
+++ b/src/pgeon/__init__.py
@@ -1,0 +1,3 @@
+from .policy_graph import *
+from .agent import Agent
+from .discretizer import Discretizer, Predicate

--- a/src/pgeon/__init__.py
+++ b/src/pgeon/__init__.py
@@ -1,3 +1,3 @@
-from .policy_graph import *
 from .agent import Agent
 from .discretizer import Discretizer, Predicate
+from .policy_graph import *


### PR DESCRIPTION
The format prehook was inadvertently removing unused imports from init files.

This change uses the flag `--ignore-init-module-imports` from https://github.com/PyCQA/autoflake/pull/42 to skip import removal from init files only.

It also reverts the changes to src/pgeon/__init__.py from https://github.com/HPAI-BSC/pgeon/pull/13, which removed all imports.