### PR TITLE
Implement PolicyRepresentation .save_csv() and .load_csv()

### DIFF
--- a/src/pgeon/discretizer.py
+++ b/src/pgeon/discretizer.py
@@ -94,7 +94,7 @@ class Discretizer(metaclass=abc.ABCMeta):
         pass
 
     @abc.abstractmethod
-    def str_to_state(self, state: str):
+    def str_to_state(self, state: str) -> StateRepresentation:
         pass
 
     @abc.abstractmethod

--- a/src/pgeon/policy_representation.py
+++ b/src/pgeon/policy_representation.py
@@ -524,6 +524,8 @@ class GraphRepresentation(PolicyRepresentation):
             next(csv_r)
 
             for state_id, value, prob, freq in csv_r:
+                # if value is None or value == "":
+                #     value = state_id
                 state_prob = float(prob)
                 state_freq = int(freq)
 
@@ -532,6 +534,12 @@ class GraphRepresentation(PolicyRepresentation):
                     "probability": state_prob,
                     "frequency": state_freq,
                 }
+                print(f"state_id: {state_id}")
+                print(f"value: {value}")
+                print(f"node_info[int({state_id})]: {node_info[int(state_id)]}")
+                print(
+                    f"discretizer.str_to_state(value): {discretizer.str_to_state(value)}"
+                )
                 representation.graph.add_node(
                     node_info[int(state_id)]["value"],
                     probability=state_prob,
@@ -550,6 +558,7 @@ class GraphRepresentation(PolicyRepresentation):
                 action = int(action)
                 prob = float(prob)
                 freq = int(freq)
+                print(f"action: {action}, prob: {prob}, freq: {freq}")
 
                 representation.graph.add_edge(
                     node_info[node_from]["value"],
@@ -558,6 +567,9 @@ class GraphRepresentation(PolicyRepresentation):
                     frequency=freq,
                     probability=prob,
                     action=action,
+                )
+                print(
+                    f"representation.get_transition_data(node_info[node_from]['value'], node_info[node_to]['value'], action): {representation.get_transition_data(node_info[node_from]['value'], node_info[node_to]['value'], action)}"
                 )
 
         return representation

--- a/src/pgeon/policy_representation.py
+++ b/src/pgeon/policy_representation.py
@@ -223,6 +223,16 @@ class GraphRepresentation(PolicyRepresentation):
         ) -> Iterator: ...
 
         @abc.abstractmethod
+        def get_node_attributes(
+            self, attribute_name: str
+        ) -> Dict[StateRepresentation, Any]: ...
+
+        @abc.abstractmethod
+        def set_node_attributes(
+            self, attributes: Dict[StateRepresentation, Any], attribute_name: str
+        ) -> None: ...
+
+        @abc.abstractmethod
         def clear(self) -> None: ...
 
         @abc.abstractmethod
@@ -296,6 +306,16 @@ class GraphRepresentation(PolicyRepresentation):
             self, node: StateRepresentation, data: bool = False
         ) -> nx.reportviews.OutMultiEdgeView:
             return self._nx_graph.out_edges(node, data=data)
+
+        def get_node_attributes(
+            self, attribute_name: str
+        ) -> Dict[StateRepresentation, Any]:
+            return nx.get_node_attributes(self._nx_graph, attribute_name)
+
+        def set_node_attributes(
+            self, attributes: Dict[StateRepresentation, Any], attribute_name: str
+        ) -> None:
+            nx.set_node_attributes(self._nx_graph, attributes, attribute_name)
 
         def clear(self) -> None:
             self._nx_graph.clear()
@@ -402,13 +422,13 @@ class GraphRepresentation(PolicyRepresentation):
         self, attribute_name: str
     ) -> Dict[StateRepresentation, Any]:
         """Get attributes for all states by name."""
-        return nx.get_node_attributes(self.graph.backend, attribute_name)
+        return self.graph.get_node_attributes(attribute_name)
 
     def set_state_attributes(
         self, attributes: Dict[StateRepresentation, Any], attribute_name: str
     ) -> None:
         """Set attributes for states."""
-        nx.set_node_attributes(self.graph.backend, attributes, attribute_name)
+        self.graph.set_node_attributes(attributes, attribute_name)
 
     def get_all_states(self) -> Collection[StateRepresentation]:
         """Get all states in the policy representation."""

--- a/src/pgeon/policy_representation.py
+++ b/src/pgeon/policy_representation.py
@@ -534,12 +534,6 @@ class GraphRepresentation(PolicyRepresentation):
                     "probability": state_prob,
                     "frequency": state_freq,
                 }
-                print(f"state_id: {state_id}")
-                print(f"value: {value}")
-                print(f"node_info[int({state_id})]: {node_info[int(state_id)]}")
-                print(
-                    f"discretizer.str_to_state(value): {discretizer.str_to_state(value)}"
-                )
                 representation.graph.add_node(
                     node_info[int(state_id)]["value"],
                     probability=state_prob,
@@ -558,7 +552,6 @@ class GraphRepresentation(PolicyRepresentation):
                 action = int(action)
                 prob = float(prob)
                 freq = int(freq)
-                print(f"action: {action}, prob: {prob}, freq: {freq}")
 
                 representation.graph.add_edge(
                     node_info[node_from]["value"],
@@ -567,9 +560,6 @@ class GraphRepresentation(PolicyRepresentation):
                     frequency=freq,
                     probability=prob,
                     action=action,
-                )
-                print(
-                    f"representation.get_transition_data(node_info[node_from]['value'], node_info[node_to]['value'], action): {representation.get_transition_data(node_info[node_from]['value'], node_info[node_to]['value'], action)}"
                 )
 
         return representation
@@ -598,8 +588,9 @@ class GraphRepresentation(PolicyRepresentation):
                     [
                         elem_position,
                         discretizer.state_to_str(node),
-                        self[node].get("probability", 0),
-                        self[node].get("frequency", 0),
+                        # TODO: Update the API for cleaner access to node attributes
+                        self.graph.nx_graph.nodes[node].get("probability", 0),
+                        self.graph.nx_graph.nodes[node].get("frequency", 0),
                     ]
                 )
 

--- a/test/domain/test_env.py
+++ b/test/domain/test_env.py
@@ -6,6 +6,7 @@ import numpy as np
 from gymnasium.core import ActType, ObsType
 
 from pgeon import Agent, Discretizer, Predicate
+from pgeon.discretizer import PredicateBasedStateRepresentation
 
 
 class State(Enum):
@@ -78,4 +79,6 @@ class TestingDiscretizer(Discretizer):
         return state.predicates[0].value[0].name
 
     def str_to_state(self, state_str):
-        return State[state_str]
+        return PredicateBasedStateRepresentation(
+            (Predicate(State, [State[state_str]]),)
+        )

--- a/test/domain/test_env.py
+++ b/test/domain/test_env.py
@@ -75,6 +75,7 @@ class TestingDiscretizer(Discretizer):
             )
 
     def state_to_str(self, state):
-        return ""
+        return state.predicates[0].value[0].name
 
-    def str_to_state(self, state_str): ...
+    def str_to_state(self, state_str):
+        return State[state_str]

--- a/test/pgeon/test_policy_representation.py
+++ b/test/pgeon/test_policy_representation.py
@@ -45,7 +45,7 @@ class TestPolicyRepresentation(unittest.TestCase):
 
     def test_initialization(self):
         """Test initialization of policy representation."""
-        self.assertIsInstance(self.representation.graph.nx_graph, nx.MultiDiGraph)
+        self.assertIsInstance(self.representation.graph.backend, nx.MultiDiGraph)
         self.assertEqual(len(self.representation.get_all_states()), 0)
         self.assertEqual(len(self.representation.get_all_transitions()), 0)
 
@@ -145,7 +145,6 @@ class TestPolicyRepresentation(unittest.TestCase):
 
         self.assertEqual(len(loaded_representation.get_all_states()), 4)
         self.assertEqual(len(loaded_representation.get_all_transitions()), 1)
-
         self.assertEqual(
             loaded_representation.get_state_attributes("frequency"),
             self.representation.get_state_attributes("frequency"),

--- a/test/pgeon/test_policy_representation.py
+++ b/test/pgeon/test_policy_representation.py
@@ -69,12 +69,9 @@ class TestPolicyRepresentation(unittest.TestCase):
         self.assertEqual(len(loaded_representation.get_all_states()), 4)
         self.assertEqual(len(loaded_representation.get_all_transitions()), 1)
 
-        # self.assertEqual(
-        #     loaded_representation.get_state_attributes("frequency"),
-        #     self.representation.get_state_attributes("frequency"),
-        # )
-        print(
-            f"loaded_representation.get_all_transitions(): {loaded_representation.get_all_transitions()}"
+        self.assertEqual(
+            loaded_representation.get_state_attributes("frequency"),
+            self.representation.get_state_attributes("frequency"),
         )
 
         self.assertEqual(

--- a/test/pgeon/test_policy_representation.py
+++ b/test/pgeon/test_policy_representation.py
@@ -69,10 +69,14 @@ class TestPolicyRepresentation(unittest.TestCase):
         self.assertEqual(len(loaded_representation.get_all_states()), 4)
         self.assertEqual(len(loaded_representation.get_all_transitions()), 1)
 
-        self.assertEqual(
-            loaded_representation.get_state_attributes("frequency"),
-            self.representation.get_state_attributes("frequency"),
+        # self.assertEqual(
+        #     loaded_representation.get_state_attributes("frequency"),
+        #     self.representation.get_state_attributes("frequency"),
+        # )
+        print(
+            f"loaded_representation.get_all_transitions(): {loaded_representation.get_all_transitions()}"
         )
+
         self.assertEqual(
             loaded_representation.get_transition_data(
                 self.state0, self.state1, self.action0

--- a/test/pgeon/test_policy_representation.py
+++ b/test/pgeon/test_policy_representation.py
@@ -49,40 +49,6 @@ class TestPolicyRepresentation(unittest.TestCase):
         self.assertEqual(len(self.representation.get_all_states()), 0)
         self.assertEqual(len(self.representation.get_all_transitions()), 0)
 
-    def test_save_load_csv(self):
-        """Test saving and loading a policy representation from CSV files."""
-        nodes_path = self.tmp_dir / "test_nodes.csv"
-        edges_path = self.tmp_dir / "test_edges.csv"
-
-        self.representation.add_states_from(
-            [self.state0, self.state1, self.state2, self.state3], frequency=1
-        )
-        self.representation.add_transition(
-            self.state0, self.state1, self.action0, frequency=5, probability=1.0
-        )
-
-        self.representation.save_csv(self.discretizer, nodes_path, edges_path)
-        loaded_representation = GraphRepresentation.load_csv(
-            "networkx", self.discretizer, nodes_path, edges_path
-        )
-
-        self.assertEqual(len(loaded_representation.get_all_states()), 4)
-        self.assertEqual(len(loaded_representation.get_all_transitions()), 1)
-
-        self.assertEqual(
-            loaded_representation.get_state_attributes("frequency"),
-            self.representation.get_state_attributes("frequency"),
-        )
-
-        self.assertEqual(
-            loaded_representation.get_transition_data(
-                self.state0, self.state1, self.action0
-            ),
-            self.representation.get_transition_data(
-                self.state0, self.state1, self.action0
-            ),
-        )
-
     def test_add_state(self):
         """Test adding states to the representation."""
         self.representation.add_state(self.state0, frequency=1, probability=0.25)
@@ -157,6 +123,45 @@ class TestPolicyRepresentation(unittest.TestCase):
         )
         self.assertEqual(transition_data["frequency"], 3)
         self.assertEqual(transition_data["probability"], 0.75)
+
+    def test_save_load_csv(self):
+        """Test saving and loading a policy representation from CSV files."""
+        nodes_path = self.tmp_dir / "test_nodes.csv"
+        edges_path = self.tmp_dir / "test_edges.csv"
+        self.maxDiff = None
+        self.representation.add_states_from(
+            [self.state0, self.state1, self.state2, self.state3],
+            frequency=1,
+            probability=0.25,
+        )
+        self.representation.add_transition(
+            self.state0, self.state1, self.action0, frequency=5, probability=1.0
+        )
+
+        self.representation.save_csv(self.discretizer, nodes_path, edges_path)
+        loaded_representation = GraphRepresentation.load_csv(
+            "networkx", self.discretizer, nodes_path, edges_path
+        )
+
+        self.assertEqual(len(loaded_representation.get_all_states()), 4)
+        self.assertEqual(len(loaded_representation.get_all_transitions()), 1)
+
+        self.assertEqual(
+            loaded_representation.get_state_attributes("frequency"),
+            self.representation.get_state_attributes("frequency"),
+        )
+        self.assertEqual(
+            loaded_representation.get_state_attributes("probability"),
+            self.representation.get_state_attributes("probability"),
+        )
+        self.assertEqual(
+            loaded_representation.get_transition_data(
+                self.state0, self.state1, self.action0
+            ),
+            self.representation.get_transition_data(
+                self.state0, self.state1, self.action0
+            ),
+        )
 
     def test_get_possible_actions(self):
         """Test getting possible actions from a state."""

--- a/test/pgeon/test_policy_representation.py
+++ b/test/pgeon/test_policy_representation.py
@@ -124,7 +124,7 @@ class TestPolicyRepresentation(unittest.TestCase):
         self.assertEqual(transition_data["frequency"], 3)
         self.assertEqual(transition_data["probability"], 0.75)
 
-    def test_save_load_csv(self):
+    def test_save_and_load_csv(self):
         """Test saving and loading a policy representation from CSV files."""
         nodes_path = self.tmp_dir / "test_nodes.csv"
         edges_path = self.tmp_dir / "test_edges.csv"

--- a/test/pgeon/test_policy_representation.py
+++ b/test/pgeon/test_policy_representation.py
@@ -1,4 +1,5 @@
 import unittest
+from pathlib import Path
 from test.domain.test_env import State, TestingDiscretizer, TestingEnv
 from typing import Dict, List, Tuple
 
@@ -33,11 +34,53 @@ class TestPolicyRepresentation(unittest.TestCase):
         self.action0: Action = 0
         self.representation = GraphRepresentation()
 
+        self.tmp_dir = Path(".tmp")
+
+    def tearDown(self):
+        """Tear down test data after each test."""
+        if self.tmp_dir.exists():
+            for file in self.tmp_dir.iterdir():
+                file.unlink()
+            self.tmp_dir.rmdir()
+
     def test_initialization(self):
         """Test initialization of policy representation."""
         self.assertIsInstance(self.representation.graph.nx_graph, nx.MultiDiGraph)
         self.assertEqual(len(self.representation.get_all_states()), 0)
         self.assertEqual(len(self.representation.get_all_transitions()), 0)
+
+    def test_save_load_csv(self):
+        """Test saving and loading a policy representation from CSV files."""
+        nodes_path = self.tmp_dir / "test_nodes.csv"
+        edges_path = self.tmp_dir / "test_edges.csv"
+
+        self.representation.add_states_from(
+            [self.state0, self.state1, self.state2, self.state3], frequency=1
+        )
+        self.representation.add_transition(
+            self.state0, self.state1, self.action0, frequency=5, probability=1.0
+        )
+
+        self.representation.save_csv(self.discretizer, nodes_path, edges_path)
+        loaded_representation = GraphRepresentation.load_csv(
+            "networkx", self.discretizer, nodes_path, edges_path
+        )
+
+        self.assertEqual(len(loaded_representation.get_all_states()), 4)
+        self.assertEqual(len(loaded_representation.get_all_transitions()), 1)
+
+        self.assertEqual(
+            loaded_representation.get_state_attributes("frequency"),
+            self.representation.get_state_attributes("frequency"),
+        )
+        self.assertEqual(
+            loaded_representation.get_transition_data(
+                self.state0, self.state1, self.action0
+            ),
+            self.representation.get_transition_data(
+                self.state0, self.state1, self.action0
+            ),
+        )
 
     def test_add_state(self):
         """Test adding states to the representation."""


### PR DESCRIPTION
- implement `save_csv()` and `load_csv()`
- add `test_save_and_load_csv()`
  1. create a simple representation
  2. save it to a temp folder
  3. load it
  4. check functional equality with original
  5. clean up temp folder
- remove `save()` and `load()`, assuming that we will always use CSV (at least for now)
- remove references to `nx` outside of `NetworkXGraph` implementation