### PR TITLE
Fix intention propagation

### DIFF
--- a/src/pgeon/intention_aware_policy_approximator.py
+++ b/src/pgeon/intention_aware_policy_approximator.py
@@ -346,29 +346,18 @@ class IntentionAwarePolicyApproximator(
                 nodes_fulfilled.append(s)
         return action_prob_distribution, nodes_fulfilled
 
-    def compute_commitment_stats(self, desire_name: str, commitment_threshold: float):
+    def compute_commitment_stats(self, desire: Desire, commitment_threshold: float):
         intention_score: List[float] = []
         nodes_with_intent: List[State] = []
         for s in self.get_all_state_ids():
             node_ints = self.get_intentions(s)
-            if isinstance(desire_name, str):
-                # intentions are stored with Desire keys; resolve by name
-                intention = 0
-                for d_obj, val in node_ints.items():
-                    try:
-                        if getattr(d_obj, "name", None) == desire_name:
-                            intention = val
-                            break
-                    except Exception:
-                        continue
-            else:
-                intention = node_ints.get(desire_name, 0)
+            intention = node_ints.get(desire, 0)
             if intention >= commitment_threshold:
                 intention_score.append(intention)
                 nodes_with_intent.append(s)
         return intention_score, nodes_with_intent
 
-    def compute_intention_metrics(self, c_threshold: float):
+    def compute_intention_metrics(self, commitment_threshold: float):
         # Returns (attributed_intention_probabilities, expected_intentions)
         attributed_intention_probabilities: Dict[str, float] = {}
         expected_intentions: Dict[str, float] = {}
@@ -376,7 +365,7 @@ class IntentionAwarePolicyApproximator(
 
         for desire in self.registered_desires:
             intention_vals, nodes = self.compute_commitment_stats(
-                desire.name, commitment_threshold=c_threshold
+                desire, commitment_threshold=commitment_threshold
             )
             int_states = [self.prob(ProbQuery(s=n)) for n in nodes]
             for n in nodes:

--- a/src/pgeon/intention_aware_policy_approximator.py
+++ b/src/pgeon/intention_aware_policy_approximator.py
@@ -87,7 +87,7 @@ class IntentionAwarePolicyApproximator(
         )
         self.registered_desires: List[Desire] = list()
         self.verbose = verbose
-        self.c_threshold = 0.5
+        self.commitment_threshold = 0.5
 
     def prob(self, query: ProbQuery) -> float:
         s, a, s_prima, given_s, given_a, given_do_a = (
@@ -514,7 +514,9 @@ class IntentionAwarePolicyApproximator(
         # is trying to further an intention. eg: if it has 5% prob of increasing a desire but 95% of decreasing it
         current_intentions = self.get_intentions(state)
         current_attr_ints = {
-            d: I_d for d, I_d in current_intentions.items() if I_d >= self.c_threshold
+            d: I_d
+            for d, I_d in current_intentions.items()
+            if I_d >= self.commitment_threshold
         }
         if len(current_attr_ints) == 0:
             return {}

--- a/src/pgeon/intention_aware_policy_approximator.py
+++ b/src/pgeon/intention_aware_policy_approximator.py
@@ -144,10 +144,14 @@ class IntentionAwarePolicyApproximator(
 
     def get_possible_actions(self, s: State) -> List[Action]:
         # Returns any a s.t. P(a|s)>0
-        return [
-            transition_data.action
+        actions_with_probs = [
+            (transition_data.action, transition_data.probability)
             for transition_data in self.policy_representation.transitions[s]
         ]
+        # Deduplicate and filter zero-probability
+        return list(
+            set([action for action, prob in actions_with_probs if prob and prob > 0])
+        )
 
     def get_possible_s_prima(self, s: State, a: Action = None) -> List[State]:
         # Returns any a s.t. P(a|s)>0

--- a/test/domain/test_env.py
+++ b/test/domain/test_env.py
@@ -14,6 +14,11 @@ class DummyState(Enum):
     ONE = auto()
     TWO = auto()
     THREE = auto()
+    FOUR = auto()
+    FIVE = auto()
+    SIX = auto()
+    SEVEN = auto()
+    EIGHT = auto()
 
 
 class TestingEnv(gymnasium.Env):

--- a/test/pgeon/test_intention_aware_policy_approximator.py
+++ b/test/pgeon/test_intention_aware_policy_approximator.py
@@ -230,7 +230,9 @@ class TestIntentionAwarePolicyApproximator(unittest.TestCase):
     def test_compute_intention_metrics(self):
         for d in self.desires:
             self.ipg.register_desire(d)
-        attrib_probs, expected = self.ipg.compute_intention_metrics(c_threshold=0.0)
+        attrib_probs, expected = self.ipg.compute_intention_metrics(
+            commitment_threshold=0.0
+        )
         # Contains entries for each desire and 'Any'
         for d in self.desires:
             self.assertIn(d.name, attrib_probs)
@@ -305,16 +307,19 @@ class TestIntentionPropagation(unittest.TestCase):
         self.assertEqual(nodes, [self.s1])
         self.assertEqual(action_probs, [1.0])
 
-    def test_commitment_and_intention_metrics(self):
+    def test_commitment_metrics(self):
         # With threshold 0, both s1 (1.0) and s0 (0.7) are counted as committed.
         intentions, nodes_with_intent = self.ipg.compute_commitment_stats(
-            self.desire.name, commitment_threshold=0.0
+            self.desire, commitment_threshold=0.0
         )
         mapping = {n: i for n, i in zip(nodes_with_intent, intentions)}
         self.assertAlmostEqual(mapping.get(self.s1, 0.0), 1.0)
         self.assertAlmostEqual(mapping.get(self.s0, 0.0), 0.7)
 
-        attrib_probs, expected = self.ipg.compute_intention_metrics(c_threshold=0.5)
+    def test_intention_metrics(self):
+        attrib_probs, expected = self.ipg.compute_intention_metrics(
+            commitment_threshold=0.5
+        )
         # At c_threshold=0.5, both s1 (1.0) and s0 (0.7) still qualify;
         # attributed probability is P(s1)+P(s0)=0.3+0.2=0.5 and
         # expected intention is (1*0.3 + 0.7*0.2)/0.5 = 0.88. "Any" matches here.

--- a/test/pgeon/test_intention_aware_policy_approximator.py
+++ b/test/pgeon/test_intention_aware_policy_approximator.py
@@ -130,7 +130,7 @@ class TestIntentionAwarePolicyApproximator(unittest.TestCase):
 
     def test_initialization(self):
         """Test that the graph is initialized correctly."""
-        self.assertEqual(self.ipg.c_threshold, 0.5)
+        self.assertEqual(self.ipg.commitment_threshold, 0.5)
         self.assertFalse(self.ipg.verbose)
         self.assertIsInstance(self.ipg.policy_representation, GraphRepresentation)
         self.assertTrue(len(list(self.ipg.policy_representation.states)) > 0)
@@ -320,7 +320,7 @@ class TestIntentionPropagation(unittest.TestCase):
         attrib_probs, expected = self.ipg.compute_intention_metrics(
             commitment_threshold=0.5
         )
-        # At c_threshold=0.5, both s1 (1.0) and s0 (0.7) still qualify;
+        # At commitment_threshold=0.5, both s1 (1.0) and s0 (0.7) still qualify;
         # attributed probability is P(s1)+P(s0)=0.3+0.2=0.5 and
         # expected intention is (1*0.3 + 0.7*0.2)/0.5 = 0.88. "Any" matches here.
         self.assertIn("reach_one", attrib_probs)


### PR DESCRIPTION
## fixed

- `propagate_intention()` now identifies if the transition fulfills the desire
- add `compute_desire_statistics()`
- add `compute_commitment_stats()`
- add `compute_intention_metrics()`

## testing

- add `TestIntentionPropagation` test class under `test_intention_aware_policy_approximator.py`, which has a more realistic representation and checks
- we will add an integration test which checks the output intentions against known correct values in a follow-up